### PR TITLE
Take clean out of Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
-script: ./gradlew clean build
+script: ./gradlew build


### PR DESCRIPTION
This isn't necessary because Travis is pulling down the fresh repository every
time.  However, due to Travis running an assemble phase before running our
script, it is resulting in the build cleaning and starting over.  This is
wasteful and doesn't buy us anything over just "./gradlew build".