### PR TITLE
Issue #66: Map Size on Safari and Mobile

### DIFF
--- a/client/src/main/webjar/map/map.scss
+++ b/client/src/main/webjar/map/map.scss
@@ -1,6 +1,10 @@
 ng-map {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   height: 100% !important;
-  width: 100%;
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
* Sets absolute positioning on ng-map for cross-browser sizing.

Closes #66.