### PR TITLE
Issue #80: Responsive Sidenav

### DIFF
--- a/client/src/main/webjar/app.scss
+++ b/client/src/main/webjar/app.scss
@@ -1,27 +1,27 @@
 html, body {
-  font-family: 'Roboto', sans-serif;
-  font-size: 14px;
-  height: 100%;
-  margin: 0;
-  padding: 0;
+    font-family: 'Roboto', sans-serif;
+    font-size: 14px;
+    height: 100%;
+    margin: 0;
+    padding: 0;
 }
 
 /* Forces components loaded from ui-router to fill the dimensions of the ui-view. */
 div[ui-view] {
-  position: relative;
+    position: relative;
 }
 
 div[ui-view] > * {
-  display: flex;
-  flex-direction: column;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
 }
 
 fieldset {
-  border: 2px groove;
-  margin-bottom: 41px;
+    border: 2px groove;
+    margin-bottom: 41px;
 }

--- a/client/src/main/webjar/create-program/create-program.component.js
+++ b/client/src/main/webjar/create-program/create-program.component.js
@@ -33,7 +33,7 @@
             $log.debug("CreateProgram Controller loaded", createProgram);
         }
 
-        /* Run createProgram when component loaded. */
+        /* Run activate when component is loaded. */
         createProgram.$onInit = activate;
     }
 

--- a/client/src/main/webjar/create-program/create-program.scss
+++ b/client/src/main/webjar/create-program/create-program.scss
@@ -1,5 +1,5 @@
 .health-bam-create-program {
-  position: absolute;
-  bottom: 20px;
-  right: 20px;
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
 }

--- a/client/src/main/webjar/main/main.component.js
+++ b/client/src/main/webjar/main/main.component.js
@@ -45,9 +45,17 @@
             john();
         }
 
-        $log.debug("Main Controller loaded", main);
+        /**
+         * Initializes the controller.
+         */
+        function activate() {
+            $log.debug("Main Controller loaded", main);
 
-        training();
+            training();
+        }
+
+        /* Run activate when component is loaded. */
+        main.$onInit = activate;
     }
 
     /* Inject dependencies. */

--- a/client/src/main/webjar/main/main.html
+++ b/client/src/main/webjar/main/main.html
@@ -1,54 +1,13 @@
 <div layout="column"
      flex>
 
-    <md-toolbar layout="row">
-
-        <div class="md-toolbar-tools">
-
-            <md-button class="md-icon-button"
-                       aria-label="Toggle Main Menu">
-                <md-icon md-font-library="material-icons">
-                    menu
-                </md-icon>
-                <md-tooltip md-direction="bottom">
-                    Main menu
-                </md-tooltip>
-            </md-button>
-
-            <img src="/images/logo-64px.png"
-                 alt="Healthy Mothers, Healthy Babies Coalition of Georgia">
-
-        </div>
-
-    </md-toolbar>
+    <health-bam-toolbar></health-bam-toolbar>
 
     <div flex="grow"
          layout="row">
 
-        <md-sidenav md-is-locked-open="true"
-                    class="md-whiteframe-z2">
-
-            <md-list>
-
-                <md-list-item>
-                    Todo - actions
-                </md-list-item>
-
-                <md-list-item>
-                    Todo - actions
-                </md-list-item>
-
-                <md-list-item>
-                    Todo - actions
-                </md-list-item>
-
-                <md-list-item>
-                    Todo - actions
-                </md-list-item>
-
-            </md-list>
-
-        </md-sidenav>
+        <health-bam-sidenav layout="column">
+        </health-bam-sidenav>
 
         <div ui-view
              flex

--- a/client/src/main/webjar/main/main.module.js
+++ b/client/src/main/webjar/main/main.module.js
@@ -7,7 +7,9 @@
             "ngMaterial",
             "ui.router",
             "ngMap",
-            "healthBam.templates"
+            "healthBam.templates",
+            "healthBam.toolbar",
+            "healthBam.sidenav"
         ]
     );
 

--- a/client/src/main/webjar/map/map.component.js
+++ b/client/src/main/webjar/map/map.component.js
@@ -13,7 +13,15 @@
     ) {
         var map = this;
 
-        $log.debug("Map Controller loaded", map);
+        /**
+         * Initializes the controller.
+         */
+        function activate() {
+            $log.debug("Map Controller loaded", map);
+        }
+
+        /* Run activate when component is loaded. */
+        map.$onInit = activate;
     }
 
     /* Inject dependencies. */

--- a/client/src/main/webjar/map/map.scss
+++ b/client/src/main/webjar/map/map.scss
@@ -1,10 +1,10 @@
 ng-map {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  height: 100% !important;
-  margin: 0;
-  padding: 0;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    height: 100% !important;
+    margin: 0;
+    padding: 0;
 }

--- a/client/src/main/webjar/sidenav/sidenav.component.js
+++ b/client/src/main/webjar/sidenav/sidenav.component.js
@@ -1,0 +1,56 @@
+(function (angular) {
+    "use strict";
+
+    var module = angular.module("healthBam.sidenav");
+
+    /**
+     * Controller for the healthBamSidenav component.
+     * @param $log
+     * @param $mdMedia
+     * @constructor
+     */
+    function SidenavController(
+        $log,
+        $mdMedia
+    ) {
+        var sidenav = this;
+
+        /**
+         * Returns true if the sidenav is locked inline visible.
+         * @returns {boolean} if sidenav should be stuck visible.
+         */
+        function isLockedOpen() {
+            return $mdMedia("gt-sm");
+        }
+
+        /**
+         * Initializes the controller.
+         */
+        function activate() {
+
+            sidenav.isLockedOpen = isLockedOpen;
+
+            $log.debug("Sidenav Controller loaded", sidenav);
+        }
+
+        /* Run activate when component is loaded. */
+        sidenav.$onInit = activate;
+    }
+
+    /* Inject dependencies. */
+    SidenavController.$inject = [
+        "$log",
+        "$mdMedia"
+    ];
+
+    /* Create healthBamSidenav component. */
+    module.component(
+        "healthBamSidenav",
+        {
+            templateUrl: "sidenav.html",
+            controller: SidenavController,
+            controllerAs: "sidenav"
+        }
+    );
+
+}(window.angular));

--- a/client/src/main/webjar/sidenav/sidenav.html
+++ b/client/src/main/webjar/sidenav/sidenav.html
@@ -1,0 +1,26 @@
+<md-sidenav flex
+            md-component-id="healthBamSidenav"
+            md-is-locked-open="sidenav.isLockedOpen()"
+            class="md-whiteframe-z2">
+
+    <md-list>
+
+        <md-list-item>
+            Todo - actions
+        </md-list-item>
+
+        <md-list-item>
+            Todo - actions
+        </md-list-item>
+
+        <md-list-item>
+            Todo - actions
+        </md-list-item>
+
+        <md-list-item>
+            Todo - actions
+        </md-list-item>
+
+    </md-list>
+
+</md-sidenav>

--- a/client/src/main/webjar/sidenav/sidenav.module.js
+++ b/client/src/main/webjar/sidenav/sidenav.module.js
@@ -1,0 +1,12 @@
+(function (angular) {
+    "use strict";
+
+    angular.module(
+        "healthBam.sidenav",
+        [
+            "ngMaterial",
+            "healthBam.templates"
+        ]
+    );
+
+}(window.angular));

--- a/client/src/main/webjar/toolbar/toolbar.component.js
+++ b/client/src/main/webjar/toolbar/toolbar.component.js
@@ -1,0 +1,56 @@
+(function (angular) {
+    "use strict";
+
+    var module = angular.module("healthBam.toolbar");
+
+    /**
+     * Controller for the healthBamToolbar component.
+     * @param $mdSidenav
+     * @param $log
+     * @constructor
+     */
+    function ToolbarController(
+        $mdSidenav,
+        $log
+    ) {
+        var toolbar = this;
+
+        /**
+         * Opens or closes the sidenav when not locked open.
+         * @returns promise from toggle action.
+         */
+        function toggleSidenav() {
+            return $mdSidenav("healthBamSidenav").toggle();
+        }
+
+        /**
+         * Initializes the controller.
+         */
+        function activate() {
+
+            toolbar.toggleSidenav = toggleSidenav;
+
+            $log.debug("Toolbar Controller loaded", toolbar);
+        }
+
+        /* Run activate when component is loaded. */
+        toolbar.$onInit = activate;
+    }
+
+    /* Inject dependencies. */
+    ToolbarController.$inject = [
+        "$mdSidenav",
+        "$log"
+    ];
+
+    /* Create healthBamToolbar component. */
+    module.component(
+        "healthBamToolbar",
+        {
+            templateUrl: "toolbar.html",
+            controller: ToolbarController,
+            controllerAs: "toolbar"
+        }
+    );
+
+}(window.angular));

--- a/client/src/main/webjar/toolbar/toolbar.html
+++ b/client/src/main/webjar/toolbar/toolbar.html
@@ -1,0 +1,23 @@
+<md-toolbar layout="row">
+
+    <div class="md-toolbar-tools">
+
+        <md-button hide-gt-sm
+                   class="md-icon-button"
+                   aria-label="Toggle side panel"
+                   ng-click="toolbar.toggleSidenav()">
+            <md-icon md-font-library="material-icons">
+                menu
+            </md-icon>
+            <md-tooltip md-direction="bottom">
+                Side panel
+            </md-tooltip>
+        </md-button>
+
+        <img class="health-bam-toolbar-logo"
+             src="/images/logo-64px.png"
+             alt="Healthy Mothers, Healthy Babies Coalition of Georgia">
+
+    </div>
+
+</md-toolbar>

--- a/client/src/main/webjar/toolbar/toolbar.module.js
+++ b/client/src/main/webjar/toolbar/toolbar.module.js
@@ -1,0 +1,12 @@
+(function (angular) {
+    "use strict";
+
+    angular.module(
+        "healthBam.toolbar",
+        [
+            "ngMaterial",
+            "healthBam.templates"
+        ]
+    );
+
+}(window.angular));

--- a/client/src/main/webjar/toolbar/toolbar.scss
+++ b/client/src/main/webjar/toolbar/toolbar.scss
@@ -1,0 +1,3 @@
+.health-bam-toolbar-logo {
+    height: 100%;
+}

--- a/client/src/test/webjar/main/main.component.spec.js
+++ b/client/src/test/webjar/main/main.component.spec.js
@@ -29,6 +29,7 @@
                     angular.mock.inject(
                         function ($injector) {
                             $componentController = $injector.get("$componentController");
+                            locals.$log = $injector.get("$log");
                         }
                     );
 
@@ -43,6 +44,19 @@
 
             it("should exist", function () {
                 expect(main).toEqual(jasmine.any(Object));
+            });
+
+            describe("$onInit", function () {
+
+                it("should log loading debug message", function () {
+                    spyOn(locals.$log, "debug");
+                    main.$onInit();
+                    expect(locals.$log.debug).toHaveBeenCalledWith(
+                        jasmine.any(String),
+                        main
+                    );
+                });
+
             });
 
         });

--- a/client/src/test/webjar/map/map.component.spec.js
+++ b/client/src/test/webjar/map/map.component.spec.js
@@ -29,6 +29,7 @@
                     angular.mock.inject(
                         function ($injector) {
                             $componentController = $injector.get("$componentController");
+                            locals.$log = $injector.get("$log");
                         }
                     );
 
@@ -43,6 +44,19 @@
 
             it("should exist", function () {
                 expect(map).toEqual(jasmine.any(Object));
+            });
+
+            describe("$onInit", function () {
+
+                it("should log loading debug message", function () {
+                    spyOn(locals.$log, "debug");
+                    map.$onInit();
+                    expect(locals.$log.debug).toHaveBeenCalledWith(
+                        jasmine.any(String),
+                        map
+                    );
+                });
+
             });
 
         });

--- a/client/src/test/webjar/sidenav/sidenav.component.spec.js
+++ b/client/src/test/webjar/sidenav/sidenav.component.spec.js
@@ -1,19 +1,19 @@
 (function (angular, jasmine, beforeEach, describe, it) {
     "use strict";
 
-    /* All of the healthBam.createProgram module's tests. */
-    describe("healthBam.createProgram module", function () {
+    /* All of the healthBam.sidenav module's tests. */
+    describe("healthBam.sidenav module", function () {
 
         beforeEach(
             function () {
                 /* Load the module to test. */
-                angular.mock.module("healthBam.createProgram");
+                angular.mock.module("healthBam.sidenav");
             }
         );
 
-        describe("CreateProgramController", function () {
+        describe("SidenavController", function () {
 
-            var createProgram,
+            var sidenav,
                 $componentController,
                 locals,
                 bindings;
@@ -29,14 +29,17 @@
                     angular.mock.inject(
                         function ($injector) {
                             $componentController = $injector.get("$componentController");
-                            locals.programFormDialogService = $injector.get("programFormDialogService");
                             locals.$log = $injector.get("$log");
                         }
                     );
 
-                    /* Get the controller for the createProgram component. */
-                    createProgram = $componentController(
-                        "healthBamCreateProgram",
+                    locals.$mdMedia = jasmine.createSpy(
+                        "$mdMedia"
+                    );
+
+                    /* Get the controller for the sidenav component. */
+                    sidenav = $componentController(
+                        "healthBamSidenav",
                         locals,
                         bindings
                     );
@@ -44,61 +47,62 @@
             );
 
             it("should exist", function () {
-                expect(createProgram).toEqual(jasmine.any(Object));
+                expect(sidenav).toEqual(jasmine.any(Object));
             });
 
             describe("$onInit", function () {
 
                 it("should log loading debug message", function () {
                     spyOn(locals.$log, "debug");
-                    createProgram.$onInit();
+                    sidenav.$onInit();
                     expect(locals.$log.debug).toHaveBeenCalledWith(
                         jasmine.any(String),
-                        createProgram
+                        sidenav
                     );
                 });
 
             });
 
-            describe("openProgramForm", function () {
+            describe("sidenav.isLockedOpen", function () {
 
                 beforeEach(
                     function () {
-                        createProgram.$onInit();
+                        sidenav.$onInit();
                     }
                 );
 
                 it("should be exposed", function () {
-                    expect(createProgram.openProgramForm).toEqual(jasmine.any(Function));
+                    expect(sidenav.isLockedOpen).toEqual(jasmine.any(Function));
                 });
 
-                it("should open dialog and return its promise", function () {
+                it("should return true for screens larger than small", function () {
 
                     var actual,
-                        expected,
-                        event;
+                        expected = true;
 
-                    expected = {
-                        fake: "promise"
-                    };
-
-                    event = {
-                        mock: "clickEvent"
-                    };
-
-                    spyOn(locals.programFormDialogService, "open");
-                    locals.programFormDialogService.open.and.returnValue(expected);
-
-                    actual = createProgram.openProgramForm(event);
-
+                    locals.$mdMedia.and.returnValue(expected);
+                    actual = sidenav.isLockedOpen();
                     expect(actual).toEqual(expected);
+                    expect(locals.$mdMedia).toHaveBeenCalledWith(
+                        "gt-sm"
+                    );
+                });
 
-                    expect(locals.programFormDialogService.open).toHaveBeenCalledWith(
-                        event
+                it("should return false for screens small or smaller", function () {
+
+                    var actual,
+                        expected = false;
+
+                    locals.$mdMedia.and.returnValue(expected);
+                    actual = sidenav.isLockedOpen();
+                    expect(actual).toEqual(expected);
+                    expect(locals.$mdMedia).toHaveBeenCalledWith(
+                        "gt-sm"
                     );
                 });
 
             });
+
         });
 
     });

--- a/client/src/test/webjar/toolbar/toolbar.component.spec.js
+++ b/client/src/test/webjar/toolbar/toolbar.component.spec.js
@@ -1,19 +1,19 @@
 (function (angular, jasmine, beforeEach, describe, it) {
     "use strict";
 
-    /* All of the healthBam.createProgram module's tests. */
-    describe("healthBam.createProgram module", function () {
+    /* All of the healthBam.toolbar module's tests. */
+    describe("healthBam.toolbar module", function () {
 
         beforeEach(
             function () {
                 /* Load the module to test. */
-                angular.mock.module("healthBam.createProgram");
+                angular.mock.module("healthBam.toolbar");
             }
         );
 
-        describe("CreateProgramController", function () {
+        describe("ToolbarController", function () {
 
-            var createProgram,
+            var toolbar,
                 $componentController,
                 locals,
                 bindings;
@@ -29,14 +29,17 @@
                     angular.mock.inject(
                         function ($injector) {
                             $componentController = $injector.get("$componentController");
-                            locals.programFormDialogService = $injector.get("programFormDialogService");
                             locals.$log = $injector.get("$log");
                         }
                     );
 
-                    /* Get the controller for the createProgram component. */
-                    createProgram = $componentController(
-                        "healthBamCreateProgram",
+                    locals.$mdSidenav = jasmine.createSpy(
+                        "$mdSidenav"
+                    );
+
+                    /* Get the controller for the toolbar component. */
+                    toolbar = $componentController(
+                        "healthBamToolbar",
                         locals,
                         bindings
                     );
@@ -44,61 +47,68 @@
             );
 
             it("should exist", function () {
-                expect(createProgram).toEqual(jasmine.any(Object));
+                expect(toolbar).toEqual(jasmine.any(Object));
             });
 
             describe("$onInit", function () {
 
                 it("should log loading debug message", function () {
                     spyOn(locals.$log, "debug");
-                    createProgram.$onInit();
+                    toolbar.$onInit();
                     expect(locals.$log.debug).toHaveBeenCalledWith(
                         jasmine.any(String),
-                        createProgram
+                        toolbar
                     );
                 });
 
             });
 
-            describe("openProgramForm", function () {
+            describe("toggleSidenav", function () {
 
                 beforeEach(
                     function () {
-                        createProgram.$onInit();
+                        toolbar.$onInit();
                     }
                 );
 
                 it("should be exposed", function () {
-                    expect(createProgram.openProgramForm).toEqual(jasmine.any(Function));
+                    expect(toolbar.toggleSidenav).toEqual(jasmine.any(Function));
                 });
 
-                it("should open dialog and return its promise", function () {
+                it("should toggle sidenav and return its promise", function () {
 
                     var actual,
                         expected,
-                        event;
+                        healthBamSidenav;
 
                     expected = {
                         fake: "promise"
                     };
 
-                    event = {
-                        mock: "clickEvent"
-                    };
+                    healthBamSidenav = jasmine.createSpyObj(
+                        "healthBamSidenav",
+                        [
+                            "toggle"
+                        ]
+                    );
 
-                    spyOn(locals.programFormDialogService, "open");
-                    locals.programFormDialogService.open.and.returnValue(expected);
+                    locals.$mdSidenav.and.returnValue(healthBamSidenav);
 
-                    actual = createProgram.openProgramForm(event);
+                    healthBamSidenav.toggle.and.returnValue(expected);
+
+                    actual = toolbar.toggleSidenav();
 
                     expect(actual).toEqual(expected);
 
-                    expect(locals.programFormDialogService.open).toHaveBeenCalledWith(
-                        event
+                    expect(locals.$mdSidenav).toHaveBeenCalledWith(
+                        "healthBamSidenav"
                     );
+
+                    expect(healthBamSidenav.toggle).toHaveBeenCalled();
                 });
 
             });
+
         });
 
     });


### PR DESCRIPTION
* Splits parent "main" view into its components.
* Creates healthbam.sidenav module & component.
* Creates healthbam.toobar module & conponent.
* Consistently indents sass files with 4 spaces.
* Registers $onInit handlers for all components.
* Enables sidenav locked open only on screens larger than small.
* Hides toolbar menu button when sidenav locked open.
* Enables toolbar menu button toggling sidenav.
* Adds many tests.