### PR TITLE
closes #113: Implement KML Web Service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,9 @@ dependencies {
     /* client library to use google maps for geocoding */
     compile("com.google.maps:google-maps-services:0.1.16")
 
+    /* using Moxy for jaxb so we can have CDATA in our xml */
+    compile("org.eclipse.persistence:org.eclipse.persistence.moxy:2.6.4")
+
     testCompile("junit:junit:4.12")
     testCompile("org.hamcrest:hamcrest-core:1.3")
     testCompile("org.mockito:mockito-all:1.10.19")

--- a/client/src/main/webjar/map/map.component.js
+++ b/client/src/main/webjar/map/map.component.js
@@ -16,6 +16,38 @@
         var map = this;
 
         /**
+         * Returns the current time in milliseconds so we can bust google's caching of our generated KML files.
+         * @returns {Number} current time in milliseconds.
+         */
+        function getMsTime() {
+            return Date.now();
+        }
+
+        /**
+         * Returns the program IDs that the user is interested in as a comma delimited string.
+         * @returns {String} comma delimited string of the IDS of the programs to display.
+         */
+        function getProgramIdsString() {
+            return "1,2";
+        }
+
+        /**
+         * Returns the protocol, host, and port part of our single-page-app's URL.
+         */
+        function getUrlPrefix() {
+            /* location.protocol includes the colon and location.host includes the port */
+            return location.protocol + "//" + location.host + "/";
+        }
+
+        /**
+         * Returns the url for google to get a generated KML file.
+         * @returns {String} full URL to generate a KML file.
+         */
+        function getKmlUrl() {
+            return getUrlPrefix() + "api/kml?bc=" + getMsTime() + "&programIds=" + getProgramIdsString();
+        }
+
+        /**
          * Gets the style of map to show.
          * Generated at https://mapstyle.withgoogle.com/.
          * @returns {Array} style definition.
@@ -63,6 +95,8 @@
          * Initializes the controller.
          */
         function activate() {
+
+            map.kmlUrl = getKmlUrl();
 
             map.programs = Program.query();
             map.mapStyle = getMapStyle();

--- a/client/src/main/webjar/map/map.html
+++ b/client/src/main/webjar/map/map.html
@@ -12,13 +12,8 @@
             map-type-control="false"
             street-view-control="false">
 
-        <custom-marker ng-repeat="program in map.programs"
-                       position="{{program.streetAddress}}, {{program.city}}, {{program.state}} {{program.zipCode}}">
-            <md-icon md-font-library="material-icons"
-                     md-colors="{color: 'primary'}">
-                place
-            </md-icon>
-        </custom-marker>
+        <kml-layer url="{{map.kmlUrl}}">
+        </kml-layer>
 
     </ng-map>
 

--- a/client/src/test/webjar/map/map.component.spec.js
+++ b/client/src/test/webjar/map/map.component.spec.js
@@ -62,6 +62,11 @@
                     expect(map.mapStyle).toEqual(jasmine.any(Array));
                 });
 
+                it("should expose kmlUrl", function () {
+                    map.$onInit();
+                    expect(map.kmlUrl).toEqual(jasmine.any(String));
+                });
+
             });
 
         });

--- a/src/main/java/org/hmhb/config/JaxbConfig.java
+++ b/src/main/java/org/hmhb/config/JaxbConfig.java
@@ -1,0 +1,21 @@
+package org.hmhb.config;
+
+import org.eclipse.persistence.jaxb.JAXBContextFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JaxbConfig {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JaxbConfig.class);
+
+    public JaxbConfig() {
+        LOGGER.debug("registering moxy's JAXBContextFactory as the jaxb context factory");
+        System.setProperty(
+                "javax.xml.bind.context.factory",
+                JAXBContextFactory.class.getName()
+        );
+    }
+
+}

--- a/src/main/java/org/hmhb/geocode/DefaultGoogleGeocodeClient.java
+++ b/src/main/java/org/hmhb/geocode/DefaultGoogleGeocodeClient.java
@@ -2,6 +2,7 @@ package org.hmhb.geocode;
 
 import javax.annotation.Nonnull;
 
+import com.codahale.metrics.annotation.Timed;
 import com.google.maps.GeoApiContext;
 import com.google.maps.GeocodingApi;
 import com.google.maps.model.GeocodingResult;
@@ -23,6 +24,7 @@ public class DefaultGoogleGeocodeClient implements GoogleGeocodeClient {
         this.context = new GeoApiContext().setApiKey("AIzaSyCZWf5alpEBF39ae49x1KIaDuMA8JiSa4o");
     }
 
+    @Timed
     @Override
     public GeocodingResult[] geocode(
             @Nonnull String address

--- a/src/main/java/org/hmhb/geocode/GoogleGeocodeService.java
+++ b/src/main/java/org/hmhb/geocode/GoogleGeocodeService.java
@@ -4,6 +4,7 @@ import javax.annotation.Nonnull;
 
 import java.util.Locale;
 
+import com.codahale.metrics.annotation.Timed;
 import com.google.maps.model.GeocodingResult;
 import org.hmhb.program.Program;
 import org.slf4j.Logger;
@@ -39,6 +40,7 @@ public class GoogleGeocodeService implements GeocodeService {
         );
     }
 
+    @Timed
     @Override
     public String getLngLat(
             @Nonnull Program program

--- a/src/main/java/org/hmhb/kml/DefaultKmlService.java
+++ b/src/main/java/org/hmhb/kml/DefaultKmlService.java
@@ -1,0 +1,188 @@
+package org.hmhb.kml;
+
+import javax.annotation.Nonnull;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.hmhb.county.County;
+import org.hmhb.kml.jaxb.KmlDocument;
+import org.hmhb.kml.jaxb.KmlIcon;
+import org.hmhb.kml.jaxb.KmlIconStyle;
+import org.hmhb.kml.jaxb.KmlLinearRing;
+import org.hmhb.kml.jaxb.KmlOuterBoundary;
+import org.hmhb.kml.jaxb.KmlPlacemark;
+import org.hmhb.kml.jaxb.KmlPoint;
+import org.hmhb.kml.jaxb.KmlPolyStyle;
+import org.hmhb.kml.jaxb.KmlPolygon;
+import org.hmhb.kml.jaxb.KmlRoot;
+import org.hmhb.kml.jaxb.KmlStyle;
+import org.hmhb.program.Program;
+import org.hmhb.program.ProgramService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import static java.util.Objects.requireNonNull;
+
+@Service
+public class DefaultKmlService implements KmlService {
+
+    // You can validate the KML with:
+    // http://www.feedvalidator.org/check.cgi?url=https%3A%2F%2Fhmhb.herokuapp.com%2Fapi%2Fkml%3FprogramIds%3D999
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultKmlService.class);
+
+    private final ProgramService programService;
+
+    @Autowired
+    public DefaultKmlService(
+            @Nonnull ProgramService programService
+    ) {
+        LOGGER.debug("constructed");
+        this.programService = requireNonNull(programService, "programService cannot be null");
+    }
+
+    private List<KmlStyle> getStyles() {
+        KmlStyle purpleShade = new KmlStyle(
+                "purpleShade",
+                new KmlPolyStyle(
+                        "66b73a67",
+                        "normal",
+                        "1",
+                        "1"
+                )
+        );
+
+        KmlStyle purpleBalloon = new KmlStyle(
+                "purpleBalloon",
+                new KmlIconStyle(
+                        new KmlIcon(
+                                // TODO - push this into a config or something
+                                "https://hmhb.herokuapp.com/images/place.png"
+                        )
+                )
+        );
+
+        return Arrays.asList(
+                purpleShade,
+                purpleBalloon
+        );
+    }
+
+    private String temporaryConvert(String shape) {
+        // TODO - after John submits the counties SQL, remove the xml from the shape data
+        return shape.replace("<Polygon><outerBoundaryIs><LinearRing><coordinates>", "")
+                .replace("</coordinates></LinearRing></outerBoundaryIs></Polygon>", "");
+    }
+
+    private String getDescription(Program program) {
+        return String.format(
+                "<p>Founded in %s.</p>",
+                program.getStartYear()
+        );
+    }
+
+    private KmlRoot convertToKml(List<Program> programs) {
+        List<KmlPlacemark> programPlacemarks = new ArrayList<>();
+
+        Set<County> counties = new HashSet<>();
+
+        for (Program program : programs) {
+
+            counties.addAll(program.getCounties());
+
+            programPlacemarks.add(
+                    new KmlPlacemark(
+                            "program-" + program.getId(),
+                            program.getName(),
+                            "#purpleBalloon",
+                            getDescription(program),
+                            new KmlPoint(
+                                    program.getCoordinates()
+                            )
+                    )
+            );
+        }
+
+        List<KmlPlacemark> countyPlacemarks = new ArrayList<>();
+        for (County county : counties) {
+            countyPlacemarks.add(
+                    new KmlPlacemark(
+                            "county-" + county.getId(),
+                            county.getName(),
+                            "#purpleShade",
+                            new KmlPolygon(
+                                    new KmlOuterBoundary(
+                                            new KmlLinearRing(
+                                                    temporaryConvert(county.getShape())
+                                            )
+                                    )
+                            )
+                    )
+            );
+        }
+
+        List<KmlPlacemark> allPlacemarks = new ArrayList<>();
+        allPlacemarks.addAll(programPlacemarks);
+        allPlacemarks.addAll(countyPlacemarks);
+
+        return new KmlRoot(
+                new KmlDocument(
+                        "HMHB",
+                        "Making an impact on the Health of Babies And Mothers!",
+                        getStyles(),
+                        allPlacemarks
+                )
+        );
+    }
+
+    private List<Long> getProgramIds(String programIdsString) {
+        List<String> programStringIds = Arrays.asList(programIdsString.split("[,]"));
+        List<Long> programIds = new ArrayList<>();
+        for (String progIdStr : programStringIds) {
+            programIds.add(Long.parseLong(progIdStr));
+        }
+        return programIds;
+    }
+
+    @Override
+    public String getKml(
+            @Nonnull String programIdsString
+    ) {
+        LOGGER.debug("getKml called: programIdsString={}", programIdsString);
+        requireNonNull(programIdsString, "programIdsString cannot be null");
+
+        List<Long> programIds = getProgramIds(programIdsString);
+        List<Program> programs = programService.getByIds(programIds);
+        LOGGER.debug("programs found: {}", programs);
+
+        KmlRoot kml = convertToKml(programs);
+
+        try {
+
+            JAXBContext jaxbContext = JAXBContext.newInstance(KmlRoot.class);
+            Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
+
+            jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+
+            StringWriter stringWriter = new StringWriter();
+
+            jaxbMarshaller.marshal(kml, stringWriter);
+
+            return stringWriter.toString();
+
+        } catch (JAXBException e) {
+            throw new RuntimeException("Failed to generate KML for programIds: " + programIdsString, e);
+        }
+    }
+
+}

--- a/src/main/java/org/hmhb/kml/KmlController.java
+++ b/src/main/java/org/hmhb/kml/KmlController.java
@@ -1,0 +1,49 @@
+package org.hmhb.kml;
+
+import javax.annotation.Nonnull;
+
+import com.codahale.metrics.annotation.Timed;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * REST endpoint to serve KML for Google Maps.
+ */
+@RestController
+public class KmlController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KmlController.class);
+
+    private final KmlService service;
+
+    @Autowired
+    public KmlController(
+            @Nonnull KmlService service
+    ) {
+        LOGGER.debug("constructed");
+        this.service = requireNonNull(service, "service cannot be null");
+    }
+
+    @Timed
+    @RequestMapping(
+            method = RequestMethod.GET,
+            produces = MediaType.TEXT_PLAIN_VALUE,
+            path = "/api/kml",
+            params = {"programIds"}
+    )
+    public String getKml(
+            @RequestParam("programIds") String programIds
+    ) {
+        LOGGER.debug("getKml called: programIds={}", programIds);
+        return service.getKml(programIds);
+    }
+
+}

--- a/src/main/java/org/hmhb/kml/KmlService.java
+++ b/src/main/java/org/hmhb/kml/KmlService.java
@@ -1,0 +1,9 @@
+package org.hmhb.kml;
+
+import javax.annotation.Nonnull;
+
+public interface KmlService {
+
+    String getKml(@Nonnull String programIdsString);
+
+}

--- a/src/main/java/org/hmhb/kml/jaxb/KmlDocument.java
+++ b/src/main/java/org/hmhb/kml/jaxb/KmlDocument.java
@@ -1,0 +1,93 @@
+package org.hmhb.kml.jaxb;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+import javax.xml.bind.annotation.XmlElement;
+
+import java.util.List;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class KmlDocument {
+
+    private final String name;
+    private final String description;
+    private final List<KmlStyle> styles;
+    private final List<KmlPlacemark> placemarks;
+
+    public KmlDocument() {
+        this.name = null;
+        this.description = null;
+        this.styles = null;
+        this.placemarks = null;
+    }
+
+    public KmlDocument(
+            @Nonnull String name,
+            @Nonnull String description,
+            @Nonnull List<KmlStyle> styles,
+            @Nonnull List<KmlPlacemark> placemarks
+    ) {
+        this.name = requireNonNull(name, "name cannot be null");
+        this.description = requireNonNull(description, "description cannot be null");
+        this.styles = requireNonNull(styles, "styles cannot be null");
+        this.placemarks = requireNonNull(placemarks, "placemarks cannot be null");
+    }
+
+    @XmlElement
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        // empty
+    }
+
+    @XmlElement
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        // empty
+    }
+
+    @XmlElement(name = "Style")
+    public List<KmlStyle> getStyles() {
+        return styles;
+    }
+
+    public void setStyles(List<KmlStyle> styles) {
+        // empty
+    }
+
+    @XmlElement(name = "Placemark")
+    public List<KmlPlacemark> getPlacemarks() {
+        return placemarks;
+    }
+
+    public void setPlacemarks(List<KmlPlacemark> placemarks) {
+        // empty
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/org/hmhb/kml/jaxb/KmlIcon.java
+++ b/src/main/java/org/hmhb/kml/jaxb/KmlIcon.java
@@ -1,0 +1,52 @@
+package org.hmhb.kml.jaxb;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+import javax.xml.bind.annotation.XmlElement;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class KmlIcon {
+
+    private final String href;
+
+    public KmlIcon() {
+        this.href = null;
+    }
+
+    public KmlIcon(
+            @Nonnull String href
+    ) {
+        this.href = requireNonNull(href, "href cannot be null");
+    }
+
+    @XmlElement
+    public String getHref() {
+        return href;
+    }
+
+    public void setHref(String href) {
+        // empty
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/org/hmhb/kml/jaxb/KmlIconStyle.java
+++ b/src/main/java/org/hmhb/kml/jaxb/KmlIconStyle.java
@@ -1,0 +1,52 @@
+package org.hmhb.kml.jaxb;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+import javax.xml.bind.annotation.XmlElement;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class KmlIconStyle {
+
+    private final KmlIcon icon;
+
+    public KmlIconStyle() {
+        this.icon = null;
+    }
+
+    public KmlIconStyle(
+            @Nonnull KmlIcon icon
+    ) {
+        this.icon = requireNonNull(icon, "icon cannot be null");
+    }
+
+    @XmlElement(name = "Icon")
+    public KmlIcon getIcon() {
+        return icon;
+    }
+
+    public void setIcon(KmlIcon icon) {
+        // empty
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/org/hmhb/kml/jaxb/KmlLinearRing.java
+++ b/src/main/java/org/hmhb/kml/jaxb/KmlLinearRing.java
@@ -1,0 +1,52 @@
+package org.hmhb.kml.jaxb;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+import javax.xml.bind.annotation.XmlElement;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class KmlLinearRing {
+
+    private final String coordinates;
+
+    public KmlLinearRing() {
+        this.coordinates = null;
+    }
+
+    public KmlLinearRing(
+            @Nonnull String coordinates
+    ) {
+        this.coordinates = requireNonNull(coordinates, "coordinates cannot be null");
+    }
+
+    @XmlElement
+    public String getCoordinates() {
+        return coordinates;
+    }
+
+    public void setCoordinates(String coordinates) {
+        // empty
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/org/hmhb/kml/jaxb/KmlOuterBoundary.java
+++ b/src/main/java/org/hmhb/kml/jaxb/KmlOuterBoundary.java
@@ -1,0 +1,52 @@
+package org.hmhb.kml.jaxb;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+import javax.xml.bind.annotation.XmlElement;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class KmlOuterBoundary {
+
+    private final KmlLinearRing linearRing;
+
+    public KmlOuterBoundary() {
+        this.linearRing = null;
+    }
+
+    public KmlOuterBoundary(
+            @Nonnull KmlLinearRing linearRing
+    ) {
+        this.linearRing = requireNonNull(linearRing, "linearRing cannot be null");
+    }
+
+    @XmlElement(name = "LinearRing")
+    public KmlLinearRing getLinearRing() {
+        return linearRing;
+    }
+
+    public void setLinearRing(KmlLinearRing linearRing) {
+        // empty
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/org/hmhb/kml/jaxb/KmlPlacemark.java
+++ b/src/main/java/org/hmhb/kml/jaxb/KmlPlacemark.java
@@ -1,0 +1,125 @@
+package org.hmhb.kml.jaxb;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.eclipse.persistence.oxm.annotations.XmlCDATA;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class KmlPlacemark {
+
+    private final String id;
+    private final String name;
+    private final String styleUrl;
+    private final String description;
+    private final KmlPoint point;
+    private final KmlPolygon polygon;
+
+    public KmlPlacemark() {
+        this.id = null;
+        this.name = null;
+        this.styleUrl = null;
+        this.description = null;
+        this.point = null;
+        this.polygon = null;
+    }
+
+    public KmlPlacemark(
+            @Nonnull String id,
+            @Nonnull String name,
+            @Nonnull String styleUrl,
+            @Nonnull KmlPolygon polygon
+    ) {
+        this.id = requireNonNull(id, "id cannot be null");
+        this.name = requireNonNull(name, "name cannot be null");
+        this.styleUrl = requireNonNull(styleUrl, "styleUrl cannot be null");
+        this.description = null;
+        this.point = null;
+        this.polygon = requireNonNull(polygon, "polygon cannot be null");
+    }
+
+    public KmlPlacemark(
+            @Nonnull String id,
+            @Nonnull String name,
+            @Nonnull String styleUrl,
+            @Nonnull String description,
+            @Nonnull KmlPoint point
+    ) {
+        this.id = requireNonNull(id, "id cannot be null");
+        this.name = requireNonNull(name, "name cannot be null");
+        this.styleUrl = requireNonNull(styleUrl, "styleUrl cannot be null");
+        this.description = requireNonNull(description, "description cannot be null");
+        this.point = requireNonNull(point, "point cannot be null");
+        this.polygon = null;
+    }
+
+    @XmlAttribute
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        // empty
+    }
+
+    @XmlElement
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        // empty
+    }
+
+    @XmlElement
+    public String getStyleUrl() {
+        return styleUrl;
+    }
+
+    public void setStyleUrl(String styleUrl) {
+        // empty
+    }
+
+    @XmlElement
+    @XmlCDATA
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        // empty
+    }
+
+    @XmlElement(name = "Point")
+    public KmlPoint getPoint() {
+        return point;
+    }
+
+    @XmlElement(name = "Polygon")
+    public KmlPolygon getPolygon() {
+        return polygon;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/org/hmhb/kml/jaxb/KmlPoint.java
+++ b/src/main/java/org/hmhb/kml/jaxb/KmlPoint.java
@@ -1,0 +1,52 @@
+package org.hmhb.kml.jaxb;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+import javax.xml.bind.annotation.XmlElement;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class KmlPoint {
+
+    private final String coordinates;
+
+    public KmlPoint() {
+        this.coordinates = null;
+    }
+
+    public KmlPoint(
+            @Nonnull String coordinates
+    ) {
+        this.coordinates = requireNonNull(coordinates, "coordinates cannot be null");
+    }
+
+    @XmlElement
+    public String getCoordinates() {
+        return coordinates;
+    }
+
+    public void setCoordinates(String coordinates) {
+        // empty
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/org/hmhb/kml/jaxb/KmlPolyStyle.java
+++ b/src/main/java/org/hmhb/kml/jaxb/KmlPolyStyle.java
@@ -1,0 +1,91 @@
+package org.hmhb.kml.jaxb;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+import javax.xml.bind.annotation.XmlElement;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class KmlPolyStyle {
+
+    private final String color;
+    private final String colorMode;
+    private final String fill;
+    private final String outline;
+
+    public KmlPolyStyle() {
+        this.color = null;
+        this.colorMode = null;
+        this.fill = null;
+        this.outline = null;
+    }
+
+    public KmlPolyStyle(
+            @Nonnull String color,
+            @Nonnull String colorMode,
+            @Nonnull String fill,
+            @Nonnull String outline
+    ) {
+        this.color = requireNonNull(color, "color cannot be null");
+        this.colorMode = requireNonNull(colorMode, "colorMode cannot be null");
+        this.fill = requireNonNull(fill, "fill cannot be null");
+        this.outline = requireNonNull(outline, "outline cannot be null");
+    }
+
+    @XmlElement
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        // empty
+    }
+
+    @XmlElement
+    public String getColorMode() {
+        return colorMode;
+    }
+
+    public void setColorMode(String colorMode) {
+        // empty
+    }
+
+    @XmlElement
+    public String getFill() {
+        return fill;
+    }
+
+    public void setFill(String fill) {
+        // empty
+    }
+
+    @XmlElement
+    public String getOutline() {
+        return outline;
+    }
+
+    public void setOutline(String outline) {
+        // empty
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/org/hmhb/kml/jaxb/KmlPolygon.java
+++ b/src/main/java/org/hmhb/kml/jaxb/KmlPolygon.java
@@ -1,0 +1,52 @@
+package org.hmhb.kml.jaxb;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+import javax.xml.bind.annotation.XmlElement;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class KmlPolygon {
+
+    private final KmlOuterBoundary outerBoundaryIs;
+
+    public KmlPolygon() {
+        this.outerBoundaryIs = null;
+    }
+
+    public KmlPolygon(
+            @Nonnull KmlOuterBoundary outerBoundaryIs
+    ) {
+        this.outerBoundaryIs = requireNonNull(outerBoundaryIs, "outerBoundaryIs cannot be null");
+    }
+
+    @XmlElement
+    public KmlOuterBoundary getOuterBoundaryIs() {
+        return outerBoundaryIs;
+    }
+
+    public void setOuterBoundaryIs(KmlOuterBoundary outerBoundaryIs) {
+        // empty
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/org/hmhb/kml/jaxb/KmlRoot.java
+++ b/src/main/java/org/hmhb/kml/jaxb/KmlRoot.java
@@ -1,0 +1,58 @@
+package org.hmhb.kml.jaxb;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+
+@XmlRootElement(
+//        namespace = "http://www.opengis.net/kml/2.2",
+        name = "kml"
+)
+@Immutable
+public class KmlRoot {
+
+    private final KmlDocument document;
+
+    public KmlRoot() {
+        this.document = null;
+    }
+
+    public KmlRoot(
+            @Nonnull KmlDocument document
+    ) {
+        this.document = requireNonNull(document, "document cannot be null");
+    }
+
+    @XmlElement(name = "Document")
+    public KmlDocument getDocument() {
+        return document;
+    }
+
+    public void setDocument(KmlDocument document) {
+        // empty
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/org/hmhb/kml/jaxb/KmlStyle.java
+++ b/src/main/java/org/hmhb/kml/jaxb/KmlStyle.java
@@ -1,0 +1,87 @@
+package org.hmhb.kml.jaxb;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class KmlStyle {
+
+    private final String id;
+    private final KmlPolyStyle polyStyle;
+    private final KmlIconStyle iconStyle;
+
+    public KmlStyle() {
+        this.id = null;
+        this.polyStyle = null;
+        this.iconStyle = null;
+    }
+
+    public KmlStyle(
+            @Nonnull String id,
+            @Nonnull KmlPolyStyle polyStyle
+    ) {
+        this.id = requireNonNull(id, "id cannot be null");
+        this.polyStyle = requireNonNull(polyStyle, "polyStyle cannot be null");
+        this.iconStyle = null;
+    }
+
+    public KmlStyle(
+            @Nonnull String id,
+            @Nonnull KmlIconStyle iconStyle
+    ) {
+        this.id = requireNonNull(id, "id cannot be null");
+        this.polyStyle = null;
+        this.iconStyle = requireNonNull(iconStyle, "iconStyle cannot be null");
+    }
+
+    @XmlAttribute
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        // empty
+    }
+
+    @XmlElement(name = "PolyStyle")
+    public KmlPolyStyle getPolyStyle() {
+        return polyStyle;
+    }
+
+    public void setPolyStyle(KmlPolyStyle polyStyle) {
+        // empty
+    }
+
+    @XmlElement(name = "IconStyle")
+    public KmlIconStyle getIconStyle() {
+        return iconStyle;
+    }
+
+    public void setIconStyle(KmlIconStyle iconStyle) {
+        // empty
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/org/hmhb/kml/jaxb/package-info.java
+++ b/src/main/java/org/hmhb/kml/jaxb/package-info.java
@@ -1,0 +1,8 @@
+@XmlSchema(
+        namespace = "http://www.opengis.net/kml/2.2",
+        elementFormDefault = XmlNsForm.QUALIFIED
+)
+package org.hmhb.kml.jaxb;
+
+import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;

--- a/src/main/java/org/hmhb/program/DefaultProgramService.java
+++ b/src/main/java/org/hmhb/program/DefaultProgramService.java
@@ -64,6 +64,16 @@ public class DefaultProgramService implements ProgramService {
 
     @Timed
     @Override
+    public List<Program> getByIds(
+            @Nonnull List<Long> ids
+    ) {
+        LOGGER.debug("getByIds called: ids={}", ids);
+        requireNonNull(ids, "ids cannot be null");
+        return dao.findByIdIn(ids);
+    }
+
+    @Timed
+    @Override
     public List<Program> getAll() {
         LOGGER.debug("getAll called");
         List<Program> target = new ArrayList<>();

--- a/src/main/java/org/hmhb/program/ProgramDao.java
+++ b/src/main/java/org/hmhb/program/ProgramDao.java
@@ -1,5 +1,6 @@
 package org.hmhb.program;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.springframework.data.repository.CrudRepository;
@@ -7,5 +8,7 @@ import org.springframework.data.repository.CrudRepository;
 public interface ProgramDao extends CrudRepository<Program, Long> {
 
     List<Program> findByOrganizationId(Long organizationId);
+
+    List<Program> findByIdIn(Collection<Long> ids);
 
 }

--- a/src/main/java/org/hmhb/program/ProgramService.java
+++ b/src/main/java/org/hmhb/program/ProgramService.java
@@ -8,6 +8,8 @@ public interface ProgramService {
 
     Program getById(@Nonnull Long id);
 
+    List<Program> getByIds(@Nonnull List<Long> ids);
+
     List<Program> getAll();
 
     Program delete(@Nonnull Long id);

--- a/src/test/java/org/hmhb/kml/KmlControllerTest.java
+++ b/src/test/java/org/hmhb/kml/KmlControllerTest.java
@@ -1,0 +1,39 @@
+package org.hmhb.kml;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link KmlController}.
+ */
+public class KmlControllerTest {
+
+    private KmlController toTest;
+
+    private KmlService service;
+
+    @Before
+    public void setUp() throws Exception {
+        service = mock(KmlService.class);
+        toTest = new KmlController(service);
+    }
+
+    @Test
+    public void testGetKml() throws Exception {
+        String input = "1,2,3";
+        String expected = "<kml></kml>";
+
+        /* Train the mocks. */
+        when(service.getKml(input)).thenReturn(expected);
+
+        /* Make the call. */
+        String actual = toTest.getKml(input);
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+}

--- a/src/test/java/org/hmhb/program/DefaultProgramServiceTest.java
+++ b/src/test/java/org/hmhb/program/DefaultProgramServiceTest.java
@@ -104,6 +104,31 @@ public class DefaultProgramServiceTest {
     }
 
     @Test
+    public void testGetByIds() throws Exception {
+        List<Long> input = Collections.singletonList(PROGRAM_ID);
+
+        Program program = createFilledInProgram();
+        program.setId(PROGRAM_ID);
+
+        List<Program> expected = Collections.singletonList(program);
+
+        /* Train the mocks. */
+        when(dao.findByIdIn(input)).thenReturn(expected);
+
+        /* Make the call. */
+        List<Program> actual = toTest.getByIds(input);
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGetByIdsNull() throws Exception {
+        /* Make the call. */
+        toTest.getByIds(null);
+    }
+
+    @Test
     public void testGetAll() throws Exception {
         List<Program> expected = Collections.singletonList(createFilledInProgram());
 


### PR DESCRIPTION
* Adds missing @Timed annotations in geocoding services.
* Adds a bulk lookup for Programs.
* Adds Kml JAXB objects to define the part of KML that we need.
* Adds Moxy and sets it as the jaxb provider.
* Updates unit tests.

A note about the JAXB objects:

JAXB requires setters and no-arg constructors even if you are only
unmarshalling.

That is why my code worked w/ simple getters & setters but broke when I made
immutable objects.

There is a way to use immutable objects with JAXB by writing a mutable class
with the getters/setters/noarg-constructor, an adapter class to tell JAXB how
to convert it, and use the @XmlJavaTypeAdapter:

http://blog.bdoughan.com/2010/12/jaxb-and-immutable-objects.html

It seems more complicated than I want.  I created the immutable classes because
the setters were error prone (some objects want either 1 thing set or the
other) for these objects.  I'm not sure whether I will use the adapter crap,
keep the current hacky empty constructor and setters, or go back to simple
mutable objects.