### PR TITLE
Issue #123: MapQuery Integration

### DIFF
--- a/client/src/main/webjar/app.js
+++ b/client/src/main/webjar/app.js
@@ -25,7 +25,9 @@
     function configureUrlProvider(
         $urlRouterProvider
     ) {
-        $urlRouterProvider.otherwise("/views/map");
+        $urlRouterProvider.otherwise(
+            "/views/map?time=" + Date.now()
+        );
     }
 
     /* Inject dependencies. */

--- a/client/src/main/webjar/error-handling/error-handling.module.js
+++ b/client/src/main/webjar/error-handling/error-handling.module.js
@@ -1,0 +1,11 @@
+(function (angular) {
+    "use strict";
+
+    angular.module(
+        "healthBam.errorHandling",
+        [
+            "ngMaterial"
+        ]
+    );
+
+}(window.angular));

--- a/client/src/main/webjar/error-handling/error-handling.service.js
+++ b/client/src/main/webjar/error-handling/error-handling.service.js
@@ -1,0 +1,52 @@
+(function (angular) {
+    "use strict";
+
+    var module = angular.module("healthBam.errorHandling");
+
+    /**
+     * Service for creating program-form dialog instances.
+     * @param $mdToast
+     * @returns errorHandlingService.
+     */
+    function errorHandlingServiceFactory(
+        $mdToast
+    ) {
+
+        /**
+         * Handles an error by showing a toast.
+         * @param message {string} to show in toast.
+         * @returns {promise} of toast.
+         */
+        function handleError(message) {
+
+            var toast;
+
+            toast = $mdToast.simple().textContent(
+                message
+            ).position(
+                "top right"
+            );
+
+            return $mdToast.show(
+                toast
+            );
+        }
+
+        /* Return instance of service. */
+        return {
+            handleError: handleError
+        };
+    }
+
+    /* Inject dependencies. */
+    errorHandlingServiceFactory.$inject = [
+        "$mdToast"
+    ];
+
+    /* Create errorHandlingService. */
+    module.factory(
+        "errorHandlingService",
+        errorHandlingServiceFactory
+    );
+
+}(window.angular));

--- a/client/src/main/webjar/map-query-form/map-query-form.component.js
+++ b/client/src/main/webjar/map-query-form/map-query-form.component.js
@@ -1,0 +1,159 @@
+(function (angular) {
+    "use strict";
+
+    var module = angular.module("healthBam.mapQueryForm");
+
+    /**
+     * Controller for the healthBamMapQueryForm component.
+     * @param MapQuery
+     * @param County
+     * @param Organization
+     * @param ProgramArea
+     * @param errorHandlingService
+     * @param $mdSidenav
+     * @param $q
+     * @param $state
+     * @param $log
+     * @constructor
+     */
+    function MapQueryFormController(
+        MapQuery,
+        County,
+        Organization,
+        ProgramArea,
+        errorHandlingService,
+        $mdSidenav,
+        $q,
+        $state,
+        $log
+    ) {
+
+        var mapQueryForm = this;
+
+        /**
+         * Runs the search by sending the MapQuery to the server.
+         */
+        function search() {
+            $log.debug("MapQueryForm.search called");
+            $state.go(
+                "map",
+                {
+                    mapQuery: mapQueryForm.mapQuery,
+                    time: Date.now()
+                }
+            );
+
+            $mdSidenav("healthBamSidenav").close();
+        }
+
+        /**
+         * Handles failure loading Counties.
+         * @param error
+         * @returns rejected {Promise} of error.
+         */
+        function handleCountiesQueryError(error) {
+            $log.debug("counties query error", error);
+            errorHandlingService.handleError("Failed to retrieve Counties.");
+            return $q.reject(error);
+        }
+
+        /**
+         * Handles failure loading Organizations.
+         * @param error
+         * @returns rejected {Promise} of error.
+         */
+        function handleOrganizationsQueryError(error) {
+            $log.debug("organizations query error", error);
+            errorHandlingService.handleError("Failed to retrieve Organizations.");
+            return $q.reject(error);
+        }
+
+        /**
+         * Handles failure loading ProgramAreas.
+         * @param error
+         * @returns rejected {Promise} of error.
+         */
+        function handleProgramAreasQueryError(error) {
+            $log.debug("program area query error", error);
+            errorHandlingService.handleError("Failed to retrieve Program Areas.");
+            return $q.reject(error);
+        }
+
+        /**
+         * Loads the data required from the server.
+         */
+        function load() {
+
+            $log.debug("MapQueryForm loading data from server");
+
+            mapQueryForm.loading = true;
+
+            mapQueryForm.counties = County.query();
+            mapQueryForm.counties.$promise.catch(handleCountiesQueryError);
+
+            mapQueryForm.organizations = Organization.query();
+            mapQueryForm.organizations.$promise.catch(handleOrganizationsQueryError);
+
+            mapQueryForm.programAreas = ProgramArea.query();
+            mapQueryForm.programAreas.$promise.catch(handleProgramAreasQueryError);
+
+            $q.all(
+                [
+                    mapQueryForm.counties.$promise,
+                    mapQueryForm.organizations.$promise,
+                    mapQueryForm.programAreas.$promise
+                ]
+            ).finally(
+                function () {
+                    mapQueryForm.loading = false;
+                    $log.debug("MapQueryForm done loading from server");
+                }
+            );
+        }
+
+        /**
+         * Initializes the controller.
+         */
+        function activate() {
+
+            load();
+
+            mapQueryForm.mapQuery = new MapQuery(
+                {
+                    search: {}
+                }
+            );
+
+            mapQueryForm.search = search;
+
+            $log.debug("MapQueryForm Controller loaded", mapQueryForm);
+        }
+
+        /* Run activate when component is loaded. */
+        mapQueryForm.$onInit = activate;
+    }
+
+    /* Inject dependencies. */
+    MapQueryFormController.$inject = [
+        "MapQuery",
+        "County",
+        "Organization",
+        "ProgramArea",
+        "errorHandlingService",
+        "$mdSidenav",
+        "$q",
+        "$state",
+        "$log"
+    ];
+
+    /* Create healthBamMapQueryForm component. */
+    module.component(
+        "healthBamMapQueryForm",
+        {
+            templateUrl: "map-query-form.html",
+            controller: MapQueryFormController,
+            controllerAs: "mapQueryForm"
+        }
+    );
+
+}(window.angular));

--- a/client/src/main/webjar/map-query-form/map-query-form.html
+++ b/client/src/main/webjar/map-query-form/map-query-form.html
@@ -1,0 +1,63 @@
+<md-content layout-padding>
+
+    <form name="mapQueryForm.searchForm"
+          ng-submit="mapQueryForm.search()">
+
+        <md-input-container class="md-block" flex>
+            <label>
+                Program area
+            </label>
+            <md-select ng-model="mapQueryForm.mapQuery.search.programArea">
+                <md-option ng-value="undefined">
+                    All program areas
+                </md-option>
+                <md-option ng-repeat="programArea in mapQueryForm.programAreas"
+                           ng-value="programArea"
+                           ng-bind="programArea.name">
+                </md-option>
+            </md-select>
+        </md-input-container>
+
+        <md-input-container class="md-block" flex>
+            <label>
+                Company/Organization
+            </label>
+            <md-select ng-model="mapQueryForm.mapQuery.search.organization">
+                <md-option ng-value="undefined">
+                    All organizations
+                </md-option>
+                <md-option ng-repeat="organization in mapQueryForm.organizations"
+                           ng-value="organization"
+                           ng-bind="organization.name">
+                </md-option>
+            </md-select>
+        </md-input-container>
+
+        <md-input-container class="md-block" flex>
+            <label>
+                County
+            </label>
+            <md-select ng-model="mapQueryForm.mapQuery.search.county">
+                <md-option ng-value="undefined">
+                    All counties
+                </md-option>
+                <md-option ng-repeat="county in mapQueryForm.counties"
+                           ng-value="county"
+                           ng-bind="county.name">
+                </md-option>
+            </md-select>
+        </md-input-container>
+
+        <div layout="row"
+             layout-align="end center">
+
+            <md-button type="submit"
+                       aria-label="Search">
+                Search
+            </md-button>
+
+        </div>
+
+    </form>
+
+</md-content>

--- a/client/src/main/webjar/map-query-form/map-query-form.module.js
+++ b/client/src/main/webjar/map-query-form/map-query-form.module.js
@@ -2,15 +2,17 @@
     "use strict";
 
     angular.module(
-        "healthBam.programFormDialog",
+        "healthBam.mapQueryForm",
         [
             "ngMaterial",
+            "ui.router",
             "healthBam.templates",
+            "healthBam.mapQuery",
             "healthBam.errorHandling",
+            "healthBam.county",
             "healthBam.program",
-            "healthBam.organization",
             "healthBam.programArea",
-            "healthBam.countiesField"
+            "healthBam.organization"
         ]
     );
 

--- a/client/src/main/webjar/map/map.component.js
+++ b/client/src/main/webjar/map/map.component.js
@@ -6,46 +6,18 @@
     /**
      * Controller for the healthBamMap component.
      * @param Program
+     * @param MapQuery
      * @param $log
+     * @param $stateParams
      * @constructor
      */
     function MapController(
         Program,
-        $log
+        MapQuery,
+        $log,
+        $stateParams
     ) {
         var map = this;
-
-        /**
-         * Returns the current time in milliseconds so we can bust google's caching of our generated KML files.
-         * @returns {Number} current time in milliseconds.
-         */
-        function getMsTime() {
-            return Date.now();
-        }
-
-        /**
-         * Returns the program IDs that the user is interested in as a comma delimited string.
-         * @returns {String} comma delimited string of the IDS of the programs to display.
-         */
-        function getProgramIdsString() {
-            return "1,2";
-        }
-
-        /**
-         * Returns the protocol, host, and port part of our single-page-app's URL.
-         */
-        function getUrlPrefix() {
-            /* location.protocol includes the colon and location.host includes the port */
-            return location.protocol + "//" + location.host + "/";
-        }
-
-        /**
-         * Returns the url for google to get a generated KML file.
-         * @returns {String} full URL to generate a KML file.
-         */
-        function getKmlUrl() {
-            return getUrlPrefix() + "api/kml?bc=" + getMsTime() + "&programIds=" + getProgramIdsString();
-        }
 
         /**
          * Gets the style of map to show.
@@ -96,7 +68,15 @@
          */
         function activate() {
 
-            map.kmlUrl = getKmlUrl();
+            if ($stateParams.mapQuery) {
+                map.mapQuery = $stateParams.mapQuery;
+
+            } else {
+                map.mapQuery = new MapQuery();
+            }
+
+            /* Run search. */
+            map.mapQuery.$save();
 
             map.programs = Program.query();
             map.mapStyle = getMapStyle();
@@ -111,7 +91,9 @@
     /* Inject dependencies. */
     MapController.$inject = [
         "Program",
-        "$log"
+        "MapQuery",
+        "$log",
+        "$stateParams"
     ];
 
     /* Create healthBamMap component. */

--- a/client/src/main/webjar/map/map.html
+++ b/client/src/main/webjar/map/map.html
@@ -1,8 +1,6 @@
 <md-content flex>
 
-    <ng-map ng-if="map.programs.$resolved"
-            center="[32.662111, -83.438306]"
-            zoom="7"
+    <ng-map ng-if="map.mapQuery.$resolved"
             default-style=""
             styles="{{map.mapStyle}}"
             zoom-control="true"
@@ -12,7 +10,7 @@
             map-type-control="false"
             street-view-control="false">
 
-        <kml-layer url="{{map.kmlUrl}}">
+        <kml-layer url="{{map.mapQuery.result.mapLayerUrl}}">
         </kml-layer>
 
     </ng-map>

--- a/client/src/main/webjar/map/map.route.js
+++ b/client/src/main/webjar/map/map.route.js
@@ -13,9 +13,12 @@
         $stateProvider.state(
             "map",
             {
-                url: "/map",
+                url: "/map?{time:int}",
                 component: "healthBamMap",
-                parent: "main"
+                parent: "main",
+                params: {
+                    mapQuery: null
+                }
             }
         );
     }

--- a/client/src/main/webjar/program-form-dialog/program-form-dialog.controller.js
+++ b/client/src/main/webjar/program-form-dialog/program-form-dialog.controller.js
@@ -10,6 +10,7 @@
      * @param $q
      * @param Organization
      * @param ProgramArea
+     * @param errorHandlingService
      * @param $log
      * @constructor
      */
@@ -19,6 +20,7 @@
         $q,
         Organization,
         ProgramArea,
+        errorHandlingService,
         $log
     ) {
         var programFormDialog = this;
@@ -49,32 +51,12 @@
         }
 
         /**
-         * Handles an error by showing a toast.
-         * @param message {string} to show in toast.
-         * @returns {promise} of toast.
-         */
-        function handleError(message) {
-
-            var toast;
-
-            toast = $mdToast.simple().textContent(
-                message
-            ).position(
-                "top right"
-            );
-
-            return $mdToast.show(
-                toast
-            );
-        }
-
-        /**
          * Handles an error saving the Program.
          * @returns rejected promise of error input.
          */
         function handleProgramSaveError(error) {
             $log.debug("program save error", error);
-            handleError("Failed to save program.");
+            errorHandlingService.handleError("Failed to save program.");
             return $q.reject(error);
         }
 
@@ -84,7 +66,7 @@
          */
         function handleProgramAreaQueryError(error) {
             $log.debug("program area query error", error);
-            handleError("Failed to retrieve Program Areas.");
+            errorHandlingService.handleError("Failed to retrieve Program Areas.");
             return $q.reject(error);
         }
 
@@ -94,7 +76,7 @@
          */
         function handleOrganizationQueryError(error) {
             $log.debug("organization query error", error);
-            handleError("Failed to retrieve Organizations.");
+            errorHandlingService.handleError("Failed to retrieve Organizations.");
             return $q.reject(error);
         }
 
@@ -207,6 +189,7 @@
         "$q",
         "Organization",
         "ProgramArea",
+        "errorHandlingService",
         "$log"
     ];
 

--- a/client/src/main/webjar/sidenav/sidenav.html
+++ b/client/src/main/webjar/sidenav/sidenav.html
@@ -3,24 +3,6 @@
             md-is-locked-open="sidenav.isLockedOpen()"
             class="md-whiteframe-z2">
 
-    <md-list>
-
-        <md-list-item>
-            Todo - actions
-        </md-list-item>
-
-        <md-list-item>
-            Todo - actions
-        </md-list-item>
-
-        <md-list-item>
-            Todo - actions
-        </md-list-item>
-
-        <md-list-item>
-            Todo - actions
-        </md-list-item>
-
-    </md-list>
+    <health-bam-map-query-form></health-bam-map-query-form>
 
 </md-sidenav>

--- a/client/src/main/webjar/sidenav/sidenav.module.js
+++ b/client/src/main/webjar/sidenav/sidenav.module.js
@@ -5,7 +5,8 @@
         "healthBam.sidenav",
         [
             "ngMaterial",
-            "healthBam.templates"
+            "healthBam.templates",
+            "healthBam.mapQueryForm"
         ]
     );
 

--- a/client/src/test/webjar/error-handling/error-handling.service.spec.js
+++ b/client/src/test/webjar/error-handling/error-handling.service.spec.js
@@ -1,0 +1,49 @@
+(function (angular, jasmine, beforeEach, describe, it, spyOn) {
+    "use strict";
+
+    describe("healthBam.errorHandling module", function () {
+
+        beforeEach(
+            function () {
+                /* Load the module to test. */
+                angular.mock.module("healthBam.errorHandling");
+            }
+        );
+
+        describe("errorHandlingService", function () {
+
+            var errorHandlingService,
+                $mdToast;
+
+            beforeEach(
+                function () {
+
+                    /* Inject dependencies. */
+                    angular.mock.inject(
+                        function ($injector) {
+                            errorHandlingService = $injector.get("errorHandlingService");
+                            $mdToast = $injector.get("$mdToast");
+                        }
+                    );
+                }
+            );
+
+            describe("errorHandlingService.handleError", function () {
+
+                it("should exist", function () {
+                    expect(errorHandlingService.handleError).toEqual(jasmine.any(Function));
+                });
+
+                it("should show toast", function () {
+                    spyOn($mdToast, "show");
+                    errorHandlingService.handleError("Test");
+                    expect($mdToast.show).toHaveBeenCalled();
+                });
+
+            });
+
+        });
+
+    });
+
+}(window.angular, window.jasmine, window.beforeEach, window.describe, window.it, window.spyOn));

--- a/client/src/test/webjar/map-query-form/map-query-form.component.spec.js
+++ b/client/src/test/webjar/map-query-form/map-query-form.component.spec.js
@@ -1,0 +1,345 @@
+(function (angular, jasmine, beforeEach, describe, it, spyOn) {
+    "use strict";
+
+    /* All of the healthBam.mapQueryForm module's tests. */
+    describe("healthBam.mapQueryForm module", function () {
+
+        beforeEach(
+            function () {
+                /* Load the module to test. */
+                angular.mock.module("healthBam.mapQueryForm");
+            }
+        );
+
+        describe("MapQueryFormController", function () {
+
+            var mapQueryForm,
+                $componentController,
+                locals,
+                bindings,
+                healthBamSidenav;
+
+            beforeEach(
+                function () {
+
+                    /* Reset variables. */
+                    locals = {};
+                    bindings = {};
+
+                    /* Inject dependencies. */
+                    angular.mock.inject(
+                        function ($injector) {
+                            $componentController = $injector.get("$componentController");
+                            locals.MapQuery = $injector.get("MapQuery");
+                            locals.County = $injector.get("County");
+                            locals.Organization = $injector.get("Organization");
+                            locals.ProgramArea = $injector.get("ProgramArea");
+                            locals.errorHandlingService = $injector.get("errorHandlingService");
+                            locals.$q = $injector.get("$q");
+                            locals.$state = $injector.get("$state");
+                            locals.$log = $injector.get("$log");
+                            locals.$httpBackend = $injector.get("$httpBackend");
+                        }
+                    );
+
+                    locals.$mdSidenav = jasmine.createSpy(
+                        "$mdSidenav"
+                    );
+
+                    healthBamSidenav = jasmine.createSpyObj(
+                        "healthBamSidenav",
+                        [
+                            "close"
+                        ]
+                    );
+
+                    spyOn(locals.errorHandlingService, "handleError");
+
+                    locals.$mdSidenav.and.returnValue(healthBamSidenav);
+
+                    /* Get the controller for the mapQueryForm component. */
+                    mapQueryForm = $componentController(
+                        "healthBamMapQueryForm",
+                        locals,
+                        bindings
+                    );
+                }
+            );
+
+            it("should exist", function () {
+                expect(mapQueryForm).toEqual(jasmine.any(Object));
+            });
+
+            describe("$onInit", function () {
+
+                it("should log loading debug message", function () {
+                    spyOn(locals.$log, "debug");
+                    mapQueryForm.$onInit();
+                    expect(locals.$log.debug).toHaveBeenCalledWith(
+                        jasmine.any(String),
+                        mapQueryForm
+                    );
+                });
+
+                it("should expose mapQuery", function () {
+                    mapQueryForm.$onInit();
+                    expect(mapQueryForm.mapQuery).toEqual(jasmine.any(Object));
+                });
+
+                it("should load & expose Counties from server", function () {
+
+                    var counties = [
+                        new locals.County(
+                            {
+                                id: 1,
+                                name: "TestCounty"
+                            }
+                        )
+                    ];
+
+                    locals.$httpBackend.expectGET(
+                        "api/counties"
+                    ).respond(
+                        angular.toJson(counties)
+                    );
+
+                    locals.$httpBackend.expectGET(
+                        "api/organizations"
+                    ).respond(
+                        angular.toJson([])
+                    );
+
+                    locals.$httpBackend.expectGET(
+                        "api/program-areas"
+                    ).respond(
+                        angular.toJson([])
+                    );
+
+                    mapQueryForm.$onInit();
+
+                    locals.$httpBackend.flush();
+
+                    expect(
+                        mapQueryForm.counties
+                    ).toEqual(
+                        jasmine.objectContaining(counties)
+                    );
+
+                    expect(
+                        locals.errorHandlingService.handleError
+                    ).not.toHaveBeenCalled();
+                });
+
+                it("should handle error fetching Counties", function () {
+
+                    locals.$httpBackend.expectGET(
+                        "api/counties"
+                    ).respond(
+                        418
+                    );
+
+                    locals.$httpBackend.expectGET(
+                        "api/organizations"
+                    ).respond(
+                        angular.toJson([])
+                    );
+
+                    locals.$httpBackend.expectGET(
+                        "api/program-areas"
+                    ).respond(
+                        angular.toJson([])
+                    );
+
+                    mapQueryForm.$onInit();
+
+                    locals.$httpBackend.flush();
+
+                    expect(
+                        locals.errorHandlingService.handleError
+                    ).toHaveBeenCalled();
+                });
+
+                it("should load & expose Organizations from server", function () {
+
+                    var organizations = [
+                        new locals.Organization(
+                            {
+                                id: 1,
+                                name: "TestOrganizations"
+                            }
+                        )
+                    ];
+
+                    locals.$httpBackend.expectGET(
+                        "api/counties"
+                    ).respond(
+                        angular.toJson([])
+                    );
+
+                    locals.$httpBackend.expectGET(
+                        "api/organizations"
+                    ).respond(
+                        organizations
+                    );
+
+                    locals.$httpBackend.expectGET(
+                        "api/program-areas"
+                    ).respond(
+                        angular.toJson([])
+                    );
+
+                    mapQueryForm.$onInit();
+
+                    locals.$httpBackend.flush();
+
+                    expect(
+                        mapQueryForm.organizations
+                    ).toEqual(
+                        jasmine.objectContaining(organizations)
+                    );
+
+                    expect(
+                        locals.errorHandlingService.handleError
+                    ).not.toHaveBeenCalled();
+                });
+
+                it("should handle error fetching Organizations", function () {
+
+                    locals.$httpBackend.expectGET(
+                        "api/counties"
+                    ).respond(
+                        angular.toJson([])
+                    );
+
+                    locals.$httpBackend.expectGET(
+                        "api/organizations"
+                    ).respond(
+                        418
+                    );
+
+                    locals.$httpBackend.expectGET(
+                        "api/program-areas"
+                    ).respond(
+                        angular.toJson([])
+                    );
+
+                    mapQueryForm.$onInit();
+
+                    locals.$httpBackend.flush();
+
+                    expect(
+                        locals.errorHandlingService.handleError
+                    ).toHaveBeenCalled();
+                });
+
+                it("should load & expose ProgramAreas from server", function () {
+
+                    var programAreas = [
+                        new locals.ProgramArea(
+                            {
+                                id: 1,
+                                name: "TestProgramAreas"
+                            }
+                        )
+                    ];
+
+                    locals.$httpBackend.expectGET(
+                        "api/counties"
+                    ).respond(
+                        angular.toJson([])
+                    );
+
+                    locals.$httpBackend.expectGET(
+                        "api/organizations"
+                    ).respond(
+                        angular.toJson([])
+                    );
+
+                    locals.$httpBackend.expectGET(
+                        "api/program-areas"
+                    ).respond(
+                        programAreas
+                    );
+
+                    mapQueryForm.$onInit();
+
+                    locals.$httpBackend.flush();
+
+                    expect(
+                        mapQueryForm.programAreas
+                    ).toEqual(
+                        jasmine.objectContaining(programAreas)
+                    );
+
+                    expect(
+                        locals.errorHandlingService.handleError
+                    ).not.toHaveBeenCalled();
+                });
+
+                it("should handle error fetching ProgramAreas", function () {
+
+                    locals.$httpBackend.expectGET(
+                        "api/counties"
+                    ).respond(
+                        angular.toJson([])
+                    );
+
+                    locals.$httpBackend.expectGET(
+                        "api/organizations"
+                    ).respond(
+                        angular.toJson([])
+                    );
+
+                    locals.$httpBackend.expectGET(
+                        "api/program-areas"
+                    ).respond(
+                        418
+                    );
+
+                    mapQueryForm.$onInit();
+
+                    locals.$httpBackend.flush();
+
+                    expect(
+                        locals.errorHandlingService.handleError
+                    ).toHaveBeenCalled();
+                });
+
+            });
+
+            describe("search", function () {
+
+                beforeEach(
+                    function () {
+                        mapQueryForm.$onInit();
+                    }
+                );
+
+                it("should be exposed", function () {
+                    expect(mapQueryForm.search).toEqual(jasmine.any(Function));
+                });
+
+                it("should navigate to map with mapQuery and close sideNav", function () {
+
+                    spyOn(locals.$state, "go");
+
+                    mapQueryForm.search();
+
+                    expect(locals.$state.go).toHaveBeenCalledWith(
+                        "map",
+                        {
+                            mapQuery: mapQueryForm.mapQuery,
+                            time: jasmine.any(Number)
+                        }
+                    );
+
+                    expect(healthBamSidenav.close).toHaveBeenCalled();
+                });
+
+            });
+
+        });
+
+    });
+
+}(window.angular, window.jasmine, window.beforeEach, window.describe, window.it, window.spyOn));

--- a/client/src/test/webjar/map/map.component.spec.js
+++ b/client/src/test/webjar/map/map.component.spec.js
@@ -62,11 +62,6 @@
                     expect(map.mapStyle).toEqual(jasmine.any(Array));
                 });
 
-                it("should expose kmlUrl", function () {
-                    map.$onInit();
-                    expect(map.kmlUrl).toEqual(jasmine.any(String));
-                });
-
             });
 
         });

--- a/src/main/java/org/hmhb/mapquery/MapQuerySearch.java
+++ b/src/main/java/org/hmhb/mapquery/MapQuerySearch.java
@@ -3,11 +3,20 @@ package org.hmhb.mapquery;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.hmhb.county.County;
+import org.hmhb.organization.Organization;
+import org.hmhb.programarea.ProgramArea;
 
 /**
  * Criteria for filtering the results on the map.
  */
 public class MapQuerySearch {
+
+    private County county;
+
+    private Organization organization;
+
+    private ProgramArea programArea;
 
     @Override
     public boolean equals(Object o) {
@@ -22,6 +31,30 @@ public class MapQuerySearch {
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);
+    }
+
+    public County getCounty() {
+        return county;
+    }
+
+    public void setCounty(County county) {
+        this.county = county;
+    }
+
+    public Organization getOrganization() {
+        return organization;
+    }
+
+    public void setOrganization(Organization organization) {
+        this.organization = organization;
+    }
+
+    public ProgramArea getProgramArea() {
+        return programArea;
+    }
+
+    public void setProgramArea(ProgramArea programArea) {
+        this.programArea = programArea;
     }
 
 }


### PR DESCRIPTION
* Adds errorHandlingService that shows toast.
* Adds mapQueryForm component to side nav.
* Adds mapQuery non-url param to map view.
* Passes mapQuery from mapQueryForm to map view as param.
* Adds county, organization, and programArea to MapQuerySearch.
* Adds time stateParam to map state to force searches to be different.
* Fixes the "all" options to be undefined.
* Adds closing sideNav on search.
* Removes URL building code from map component.
* Removes center and zoom from ng-map; auto-aligns with KML.