### PR TITLE
closes #133: Redirect to https

### DIFF
--- a/src/main/java/org/hmhb/config/HttpsConfig.java
+++ b/src/main/java/org/hmhb/config/HttpsConfig.java
@@ -1,0 +1,19 @@
+package org.hmhb.config;
+
+import org.hmhb.https.PreferHttpsFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class HttpsConfig {
+
+    @Bean
+    public FilterRegistrationBean provideHttpsFilter() {
+        FilterRegistrationBean registration = new FilterRegistrationBean();
+        registration.setFilter(new PreferHttpsFilter());
+        registration.setOrder(100);
+        return registration;
+    }
+
+}

--- a/src/main/java/org/hmhb/county/County.java
+++ b/src/main/java/org/hmhb/county/County.java
@@ -41,7 +41,12 @@ public class County {
 
     @Override
     public String toString() {
-        return ToStringBuilder.reflectionToString(this);
+        return new ToStringBuilder(this)
+                .append("id", id)
+                .append("name", name)
+                .append("state", state)
+                /* I'm leaving out "shape" because it is very spammy. */
+                .toString();
     }
 
     public Long getId() {

--- a/src/main/java/org/hmhb/https/PreferHttpsFilter.java
+++ b/src/main/java/org/hmhb/https/PreferHttpsFilter.java
@@ -1,0 +1,79 @@
+package org.hmhb.https;
+
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PreferHttpsFilter implements Filter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PreferHttpsFilter.class);
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        LOGGER.debug("init called");
+    }
+
+    @Override
+    public void doFilter(
+            ServletRequest servletRequest,
+            ServletResponse servletResponse,
+            FilterChain chain
+    ) throws IOException, ServletException {
+        LOGGER.debug("doFilter called");
+
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        try {
+            /*
+             * Code inspired by:
+             * https://gist.github.com/qerub/8975333
+             * http://stackoverflow.com/questions/9389211/using-filters-to-redirect-from-https-to-http
+             */
+            URI originalUri = new URI(request.getRequestURL().toString());
+
+            LOGGER.debug("isSecure={}, port={}, originalUri={}", request.isSecure(), originalUri.getPort(), originalUri);
+
+            /* If the request is http and isn't local (local is using a non-standard port), redirect to https. */
+            if (!request.isSecure() && originalUri.getPort() == -1) {
+
+                URI forwardUrl = new URI(
+                        "https",
+                        originalUri.getUserInfo(),
+                        originalUri.getHost(),
+                        originalUri.getPort(),
+                        originalUri.getPath(),
+                        originalUri.getQuery(),
+                        null
+                );
+
+                response.sendRedirect(forwardUrl.toString());
+            } else {
+                chain.doFilter(request, response);
+            }
+
+        } catch (URISyntaxException e) {
+            throw new ServletException("Failed to construct URI!", e);
+        }
+
+    }
+
+    @Override
+    public void destroy() {
+        LOGGER.debug("destroy called");
+    }
+
+}

--- a/src/test/java/org/hmhb/county/CountyTest.java
+++ b/src/test/java/org/hmhb/county/CountyTest.java
@@ -1,0 +1,32 @@
+package org.hmhb.county;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit test for {@link County}.
+ */
+public class CountyTest {
+
+    private static final Long ID = 12345678901L;
+    private static final String NAME = "unit-test-name";
+    private static final String STATE = "unit-test-state";
+    private static final String GEO_SHAPE = "unit-test-coordinates";
+
+    @Test
+    public void testToString() throws Exception {
+        County county = new County();
+        county.setId(ID);
+        county.setName(NAME);
+        county.setState(STATE);
+        county.setShape(GEO_SHAPE);
+
+        assertTrue(county.toString().contains(ID.toString()));
+        assertTrue(county.toString().contains(NAME));
+        assertTrue(county.toString().contains(STATE));
+        /* Don't include the shape, it is too spammy in the logs. */
+        assertFalse(county.toString().contains(GEO_SHAPE));
+    }
+
+}

--- a/src/test/java/org/hmhb/https/PreferHttpsFilterTest.java
+++ b/src/test/java/org/hmhb/https/PreferHttpsFilterTest.java
@@ -1,0 +1,80 @@
+package org.hmhb.https;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link PreferHttpsFilter}.
+ */
+public class PreferHttpsFilterTest {
+
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private FilterChain chain;
+
+    private PreferHttpsFilter toTest;
+
+    @Before
+    public void setUp() throws Exception {
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        chain = mock(FilterChain.class);
+
+        toTest = new PreferHttpsFilter();
+    }
+
+    @Test
+    public void testDoFilter_ServerRunningOnLocalhost() throws Exception {
+        StringBuffer sb = new StringBuffer("http://localhost:8080/api/blah");
+
+        /* Train the mocks. */
+        when(request.getRequestURL()).thenReturn(sb);
+        when(request.isSecure()).thenReturn(false);
+
+        /* Make the call. */
+        toTest.doFilter(request, response, chain);
+
+        /* Verify the results. */
+        verify(response, never()).sendRedirect(anyString());
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    public void testDoFilter_ServerRunningOnHeroku() throws Exception {
+        StringBuffer sb = new StringBuffer("http://hmhb.herokuapp.com/api/blah");
+
+        /* Train the mocks. */
+        when(request.getRequestURL()).thenReturn(sb);
+        when(request.isSecure()).thenReturn(false);
+
+        /* Make the call. */
+        toTest.doFilter(request, response, chain);
+
+        /* Verify the results. */
+        verify(response).sendRedirect("https://hmhb.herokuapp.com/api/blah");
+        verify(chain, never()).doFilter(request, response);
+    }
+
+    @Test
+    public void testDoFilter_ServerRunningOnHerokuButAlreadyHttps() throws Exception {
+        StringBuffer sb = new StringBuffer("https://localhost:8080/api/blah");
+
+        /* Train the mocks. */
+        when(request.getRequestURL()).thenReturn(sb);
+        when(request.isSecure()).thenReturn(true);
+
+        /* Make the call. */
+        toTest.doFilter(request, response, chain);
+
+        /* Verify the results. */
+        verify(response, never()).sendRedirect(anyString());
+        verify(chain).doFilter(request, response);
+    }
+
+}


### PR DESCRIPTION
* Removes shape from County's toString because it was spammy.
* Adds servlet filter to redirect to https when running in the cloud.
* Updates unit tests.