### PR TITLE
closes #124: Remove hardcoded hostnames in code

### DIFF
--- a/src/main/java/org/hmhb/kml/DefaultKmlService.java
+++ b/src/main/java/org/hmhb/kml/DefaultKmlService.java
@@ -24,6 +24,7 @@ import org.hmhb.kml.jaxb.KmlRoot;
 import org.hmhb.kml.jaxb.KmlStyle;
 import org.hmhb.program.Program;
 import org.hmhb.program.ProgramService;
+import org.hmhb.url.UrlService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,17 +44,20 @@ public class DefaultKmlService implements KmlService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultKmlService.class);
 
+    private final UrlService urlService;
     private final KmlPlacemarkService placemarkService;
     private final CountyService countyService;
     private final ProgramService programService;
 
     @Autowired
     public DefaultKmlService(
+            @Nonnull UrlService urlService,
             @Nonnull KmlPlacemarkService placemarkService,
             @Nonnull CountyService countyService,
             @Nonnull ProgramService programService
     ) {
         LOGGER.debug("constructed");
+        this.urlService = requireNonNull(urlService, "urlService cannot be null");
         this.placemarkService = requireNonNull(placemarkService, "placemarkService cannot be null");
         this.countyService = requireNonNull(countyService, "countyService cannot be null");
         this.programService = requireNonNull(programService, "programService cannot be null");
@@ -84,8 +88,7 @@ public class DefaultKmlService implements KmlService {
                 PROGRAM_STYLE,
                 new KmlIconStyle(
                         new KmlIcon(
-                                // TODO - push this into a config or something
-                                "https://hmhb.herokuapp.com/images/place.png"
+                                urlService.getUrlPrefix() + "/images/place.png"
                         )
                 )
         );

--- a/src/main/java/org/hmhb/mapquery/DefaultMapQueryService.java
+++ b/src/main/java/org/hmhb/mapquery/DefaultMapQueryService.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import com.codahale.metrics.annotation.Timed;
 import org.hmhb.program.Program;
 import org.hmhb.program.ProgramService;
+import org.hmhb.url.UrlService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,12 +24,15 @@ public class DefaultMapQueryService implements MapQueryService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultMapQueryService.class);
 
+    private final UrlService urlService;
     private final ProgramService programService;
 
     @Autowired
     public DefaultMapQueryService(
+            @Nonnull UrlService urlService,
             @Nonnull ProgramService programService
     ) {
+        this.urlService = requireNonNull(urlService, "urlService cannot be null");
         this.programService = requireNonNull(programService, "programService cannot be null");
     }
 
@@ -50,8 +54,7 @@ public class DefaultMapQueryService implements MapQueryService {
         MapQueryResult result = new MapQueryResult();
         result.setPrograms(programs);
         result.setMapLayerUrl(
-                // TODO - extract this to config or something
-                "https://hmhb.herokuapp.com/api/kml"
+                urlService.getUrlPrefix() + "/api/kml"
                         + "?programIds=" + commaSeparatedProgramIds
                         + "&time=" + System.currentTimeMillis()
         );

--- a/src/main/java/org/hmhb/url/DefaultUrlService.java
+++ b/src/main/java/org/hmhb/url/DefaultUrlService.java
@@ -1,0 +1,48 @@
+package org.hmhb.url;
+
+import javax.annotation.Nonnull;
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+
+import static java.util.Objects.requireNonNull;
+
+@Service
+public class DefaultUrlService implements UrlService {
+
+    private final HttpServletRequest request;
+    private final Environment environment;
+
+    @Autowired
+    public DefaultUrlService(
+            @Nonnull HttpServletRequest request,
+            @Nonnull Environment environment
+    ) {
+        this.request = requireNonNull(request, "request cannot be null");
+        this.environment = requireNonNull(environment, "environment cannot be null");
+    }
+
+    @Override
+    public String getUrlPrefix() {
+
+        String configuredUrlPrefix = environment.getProperty("hmhb.url.prefix");
+
+        if (StringUtils.isNotBlank(configuredUrlPrefix)) {
+            return configuredUrlPrefix;
+        }
+
+        String scheme = request.getScheme();
+        String hostname = request.getServerName();
+        int port = request.getServerPort();
+
+        if (port != -1) {
+            return scheme + "://" + hostname + ":" + port;
+        } else {
+            return scheme + "://" + hostname;
+        }
+    }
+
+}

--- a/src/main/java/org/hmhb/url/UrlService.java
+++ b/src/main/java/org/hmhb/url/UrlService.java
@@ -1,0 +1,7 @@
+package org.hmhb.url;
+
+public interface UrlService {
+
+    String getUrlPrefix();
+
+}

--- a/src/test/java/org/hmhb/kml/DefaultKmlServiceTest.java
+++ b/src/test/java/org/hmhb/kml/DefaultKmlServiceTest.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 
 import org.hmhb.county.CountyService;
 import org.hmhb.program.ProgramService;
+import org.hmhb.url.UrlService;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -15,7 +16,6 @@ import static org.mockito.Mockito.*;
  */
 public class DefaultKmlServiceTest {
 
-    private KmlPlacemarkService placemarkService;
     private CountyService countyService;
     private ProgramService programService;
 
@@ -23,10 +23,11 @@ public class DefaultKmlServiceTest {
 
     @Before
     public void setUp() throws Exception {
-        placemarkService = mock(KmlPlacemarkService.class);
+        UrlService urlService = mock(UrlService.class);
+        KmlPlacemarkService placemarkService = mock(KmlPlacemarkService.class);
         countyService = mock(CountyService.class);
         programService = mock(ProgramService.class);
-        toTest = new DefaultKmlService(placemarkService, countyService, programService);
+        toTest = new DefaultKmlService(urlService, placemarkService, countyService, programService);
     }
 
     @Test

--- a/src/test/java/org/hmhb/mapquery/DefaultMapQueryServiceTest.java
+++ b/src/test/java/org/hmhb/mapquery/DefaultMapQueryServiceTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.hmhb.organization.Organization;
 import org.hmhb.program.Program;
 import org.hmhb.program.ProgramService;
+import org.hmhb.url.UrlService;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -21,15 +22,18 @@ public class DefaultMapQueryServiceTest {
     private static final Long PROGRAM_ID_1 = 1001L;
     private static final Long PROGRAM_ID_2 = 1002L;
     private static final Long ORG_ID = 2001L;
+    private static final String URL_PREFIX = "http://localhost:8080";
 
     private DefaultMapQueryService toTest;
 
-    private ProgramService service;
+    private UrlService urlService;
+    private ProgramService programService;
 
     @Before
     public void setUp() throws Exception {
-        service = mock(ProgramService.class);
-        toTest = new DefaultMapQueryService(service);
+        urlService = mock(UrlService.class);
+        programService = mock(ProgramService.class);
+        toTest = new DefaultMapQueryService(urlService, programService);
     }
 
     @Test
@@ -63,7 +67,8 @@ public class DefaultMapQueryServiceTest {
         expected.setResult(result);
 
         /* Train the mocks. */
-        when(service.search(input)).thenReturn(programs);
+        when(programService.search(input)).thenReturn(programs);
+        when(urlService.getUrlPrefix()).thenReturn(URL_PREFIX);
 
         /* Make the call. */
         MapQuery actual = toTest.search(input);
@@ -77,7 +82,7 @@ public class DefaultMapQueryServiceTest {
                 "Didn't start with expected: " + actual.getResult().getMapLayerUrl(),
                 actual.getResult()
                         .getMapLayerUrl()
-                        .startsWith("https://hmhb.herokuapp.com/api/kml?programIds=1001,1002&time=")
+                        .startsWith(URL_PREFIX + "/api/kml?programIds=1001,1002&time=")
         );
         assertEquals(
                 programs,
@@ -107,7 +112,8 @@ public class DefaultMapQueryServiceTest {
         expected.setResult(result);
 
         /* Train the mocks. */
-        when(service.search(input)).thenReturn(programs);
+        when(programService.search(input)).thenReturn(programs);
+        when(urlService.getUrlPrefix()).thenReturn(URL_PREFIX);
 
         /* Make the call. */
         MapQuery actual = toTest.search(input);
@@ -121,7 +127,7 @@ public class DefaultMapQueryServiceTest {
                 "Didn't start with expected: " + actual.getResult().getMapLayerUrl(),
                 actual.getResult()
                         .getMapLayerUrl()
-                        .startsWith("https://hmhb.herokuapp.com/api/kml?programIds=&time=")
+                        .startsWith(URL_PREFIX + "/api/kml?programIds=&time=")
         );
         assertEquals(
                 programs,

--- a/src/test/java/org/hmhb/url/DefaultUrlServiceTest.java
+++ b/src/test/java/org/hmhb/url/DefaultUrlServiceTest.java
@@ -1,0 +1,114 @@
+package org.hmhb.url;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.env.Environment;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link DefaultUrlService}.
+ */
+public class DefaultUrlServiceTest {
+
+    private HttpServletRequest request;
+    private Environment environment;
+
+    private DefaultUrlService toTest;
+
+    @Before
+    public void setUp() throws Exception {
+        request = mock(HttpServletRequest.class);
+        environment = mock(Environment.class);
+        toTest = new DefaultUrlService(request, environment);
+    }
+
+    @Test
+    public void testGetUrlPrefix() throws Exception {
+        String expected = "https://hmhb.herokuapp.com:443";
+
+        /* Train the mocks. */
+        when(environment.getProperty("hmhb.url.prefix")).thenReturn(null);
+        when(request.getScheme()).thenReturn("https");
+        when(request.getServerName()).thenReturn("hmhb.herokuapp.com");
+        when(request.getServerPort()).thenReturn(443);
+
+        /* Make the call. */
+        String actual = toTest.getUrlPrefix();
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetUrlPrefixNoPortSpecified() throws Exception {
+        String expected = "https://hmhb.herokuapp.com";
+
+        /* Train the mocks. */
+        when(environment.getProperty("hmhb.url.prefix")).thenReturn(null);
+        when(request.getScheme()).thenReturn("https");
+        when(request.getServerName()).thenReturn("hmhb.herokuapp.com");
+        when(request.getServerPort()).thenReturn(-1);
+
+        /* Make the call. */
+        String actual = toTest.getUrlPrefix();
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetUrlPrefixConfigOverride() throws Exception {
+        String expected = "https://hmhb.herokuapp.com";
+
+        /* Train the mocks. */
+        when(environment.getProperty("hmhb.url.prefix")).thenReturn(expected);
+        when(request.getScheme()).thenReturn("http");
+        when(request.getServerName()).thenReturn("localhost");
+        when(request.getServerPort()).thenReturn(8080);
+
+        /* Make the call. */
+        String actual = toTest.getUrlPrefix();
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetUrlPrefixConfigOverrideIsEmpty() throws Exception {
+        String expected = "http://localhost:8080";
+
+        /* Train the mocks. */
+        when(environment.getProperty("hmhb.url.prefix")).thenReturn("");
+        when(request.getScheme()).thenReturn("http");
+        when(request.getServerName()).thenReturn("localhost");
+        when(request.getServerPort()).thenReturn(8080);
+
+        /* Make the call. */
+        String actual = toTest.getUrlPrefix();
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetUrlPrefixConfigOverrideIsSpace() throws Exception {
+        String expected = "http://localhost:8080";
+
+        /* Train the mocks. */
+        when(environment.getProperty("hmhb.url.prefix")).thenReturn("   ");
+        when(request.getScheme()).thenReturn("http");
+        when(request.getServerName()).thenReturn("localhost");
+        when(request.getServerPort()).thenReturn(8080);
+
+        /* Make the call. */
+        String actual = toTest.getUrlPrefix();
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+}


### PR DESCRIPTION
* Adds DefaultUrlService to get protocol/hostname/port info from request.
* Adds ability to configure override for protocol/hostname/port with
  a system parameter (hmhb.url.prefix).
* Removes hardcoded hmhb.herokuapp.com in DefaultKmlService.
* Removes hardcoded hmhb.herokuapp.com in DefaultMapQueryService.
* Updates unit tests.