### PR TITLE
closes #186: Make ZipCode Optional with Geocode

### DIFF
--- a/client/src/main/webjar/program-form-dialog/program-form-dialog.html
+++ b/client/src/main/webjar/program-form-dialog/program-form-dialog.html
@@ -183,8 +183,7 @@
                                 Postal code
                             </label>
                             <input name="programZip"
-                                   ng-model="programFormDialog.program.zipCode"
-                                   required>
+                                   ng-model="programFormDialog.program.zipCode">
                         </md-input-container>
 
                     </div>

--- a/src/main/java/org/hmhb/geocode/GeocodeService.java
+++ b/src/main/java/org/hmhb/geocode/GeocodeService.java
@@ -6,7 +6,7 @@ import org.hmhb.program.Program;
 
 public interface GeocodeService {
 
-    String getLngLat(
+    LocationInfo getLocationInfo(
             @Nonnull Program program
     );
 

--- a/src/main/java/org/hmhb/geocode/LocationInfo.java
+++ b/src/main/java/org/hmhb/geocode/LocationInfo.java
@@ -1,0 +1,43 @@
+package org.hmhb.geocode;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+public class LocationInfo {
+
+    private String zipCode;
+    private String lngLat;
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    public String getZipCode() {
+        return zipCode;
+    }
+
+    public void setZipCode(String zipCode) {
+        this.zipCode = zipCode;
+    }
+
+    public String getLngLat() {
+        return lngLat;
+    }
+
+    public void setLngLat(String lngLat) {
+        this.lngLat = lngLat;
+    }
+
+}

--- a/src/main/java/org/hmhb/program/DefaultProgramService.java
+++ b/src/main/java/org/hmhb/program/DefaultProgramService.java
@@ -16,6 +16,7 @@ import org.hmhb.exception.program.ProgramOrganizationRequiredException;
 import org.hmhb.exception.program.ProgramStateRequiredException;
 import org.hmhb.exception.program.ProgramZipCodeRequiredException;
 import org.hmhb.geocode.GeocodeService;
+import org.hmhb.geocode.LocationInfo;
 import org.hmhb.mapquery.MapQuery;
 import org.hmhb.mapquery.MapQuerySearch;
 import org.hmhb.organization.Organization;
@@ -279,6 +280,8 @@ public class DefaultProgramService implements ProgramService {
             throw new ProgramStateRequiredException();
         }
 
+        fillCoordinatesAndZip(program);
+
         if (StringUtils.isBlank(program.getZipCode())) {
             throw new ProgramZipCodeRequiredException();
         }
@@ -300,14 +303,14 @@ public class DefaultProgramService implements ProgramService {
             program.setUpdatedOn(auditHelper.getCurrentTime());
         }
 
-        fillCoordinates(program);
-
         return dao.save(program);
 
     }
 
-    private void fillCoordinates(Program program) {
-        program.setCoordinates(geocodeService.getLngLat(program));
+    private void fillCoordinatesAndZip(Program program) {
+        LocationInfo locationInfo = geocodeService.getLocationInfo(program);
+        program.setZipCode(locationInfo.getZipCode());
+        program.setCoordinates(locationInfo.getLngLat());
     }
 
 }

--- a/src/test/java/org/hmhb/geocode/GoogleGeocodeServiceTest.java
+++ b/src/test/java/org/hmhb/geocode/GoogleGeocodeServiceTest.java
@@ -1,5 +1,7 @@
 package org.hmhb.geocode;
 
+import com.google.maps.model.AddressComponent;
+import com.google.maps.model.AddressComponentType;
 import com.google.maps.model.GeocodingResult;
 import com.google.maps.model.Geometry;
 import com.google.maps.model.LatLng;
@@ -26,32 +28,76 @@ public class GoogleGeocodeServiceTest {
     }
 
     @Test
-    public void testGetLngLat() throws Exception {
+    public void testGetLocationInfo() throws Exception {
+        String zipCode = "30332";
+
         Program program = new Program();
         program.setCity("Atlanta");
         program.setState("GA");
         program.setStreetAddress("123 Peachtree St.");
-        program.setZipCode("30332");
+        program.setZipCode(zipCode);
 
         String expectedFormattedAddress = "123 Peachtree St. Atlanta, GA 30332";
 
-        String expectedLngLat = "-1.23456789,9.87654321";
+        LocationInfo expected = new LocationInfo();
+        expected.setLngLat("-1.23456789,9.87654321");
+        expected.setZipCode(zipCode);
 
+        AddressComponent addressComponent = new AddressComponent();
+        addressComponent.longName = zipCode;
+        addressComponent.types = new AddressComponentType[] {AddressComponentType.POSTAL_CODE};
         LatLng latLng = new LatLng(9.87654321, -1.23456789);
         Geometry geometry = new Geometry();
         geometry.location = latLng;
         GeocodingResult geocodingResult = new GeocodingResult();
         geocodingResult.geometry = geometry;
+        geocodingResult.addressComponents = new AddressComponent[] {addressComponent};
         GeocodingResult[] expectedGeocodingResult = new GeocodingResult[] {geocodingResult};
 
         /* Train the mocks. */
         when(googleGeocodeClient.geocode(expectedFormattedAddress)).thenReturn(expectedGeocodingResult);
 
         /* Make the call. */
-        String actual = toTest.getLngLat(program);
+        LocationInfo actual = toTest.getLocationInfo(program);
 
         /* Verify the results. */
-        assertEquals(expectedLngLat, actual);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetLocationInfoFillZipAlso() throws Exception {
+        String zipCode = "30332";
+
+        Program program = new Program();
+        program.setCity("Atlanta");
+        program.setState("GA");
+        program.setStreetAddress("123 Peachtree St.");
+
+        String expectedFormattedAddress = "123 Peachtree St. Atlanta, GA ";
+
+        LocationInfo expected = new LocationInfo();
+        expected.setLngLat("-1.23456789,9.87654321");
+        expected.setZipCode(zipCode);
+
+        AddressComponent addressComponent = new AddressComponent();
+        addressComponent.longName = zipCode;
+        addressComponent.types = new AddressComponentType[] {AddressComponentType.POSTAL_CODE};
+        LatLng latLng = new LatLng(9.87654321, -1.23456789);
+        Geometry geometry = new Geometry();
+        geometry.location = latLng;
+        GeocodingResult geocodingResult = new GeocodingResult();
+        geocodingResult.geometry = geometry;
+        geocodingResult.addressComponents = new AddressComponent[] {addressComponent};
+        GeocodingResult[] expectedGeocodingResult = new GeocodingResult[] {geocodingResult};
+
+        /* Train the mocks. */
+        when(googleGeocodeClient.geocode(expectedFormattedAddress)).thenReturn(expectedGeocodingResult);
+
+        /* Make the call. */
+        LocationInfo actual = toTest.getLocationInfo(program);
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
     }
 
 }

--- a/src/test/java/org/hmhb/program/DefaultProgramServiceTest.java
+++ b/src/test/java/org/hmhb/program/DefaultProgramServiceTest.java
@@ -12,6 +12,7 @@ import org.hmhb.exception.program.ProgramOrganizationRequiredException;
 import org.hmhb.exception.program.ProgramStateRequiredException;
 import org.hmhb.exception.program.ProgramZipCodeRequiredException;
 import org.hmhb.geocode.GeocodeService;
+import org.hmhb.geocode.LocationInfo;
 import org.hmhb.mapquery.MapQuery;
 import org.hmhb.mapquery.MapQuerySearch;
 import org.hmhb.organization.Organization;
@@ -61,6 +62,15 @@ public class DefaultProgramServiceTest {
         dao = mock(ProgramDao.class);
 
         toTest = new DefaultProgramService(auditHelper, geocodeService, organizationService, dao);
+    }
+
+    private LocationInfo createLocationInfo() {
+        LocationInfo info = new LocationInfo();
+
+        info.setLngLat(GEO_CODE);
+        info.setZipCode(ZIP_CODE);
+
+        return info;
     }
 
     private County createCounty() {
@@ -233,18 +243,6 @@ public class DefaultProgramServiceTest {
         toTest.save(input);
     }
 
-    @Test
-    public void testSaveCreateNewNullStartYear() throws Exception {
-        Program input = createFilledInProgram();
-        input.setId(null);
-        input.setStartYear(null);
-
-        /* Make the call. */
-        toTest.save(input);
-
-        /* Should not blow up.  After receiving some customer data, we discovered that this should be allowed. */
-    }
-
     @Test(expected = ProgramStateRequiredException.class)
     public void testSaveCreateNewNullState() throws Exception {
         Program input = createFilledInProgram();
@@ -275,14 +273,59 @@ public class DefaultProgramServiceTest {
         toTest.save(input);
     }
 
+    @Test
+    public void testSaveCreateNewNullZipCodeButGoogleFoundIt() throws Exception {
+        Program input = createFilledInProgram();
+        input.setId(null);
+        input.setZipCode(null);
+
+        /* Train the mocks. */
+        when(organizationService.getById(ORG_ID)).thenReturn(createOrg());
+        when(auditHelper.getCurrentUser()).thenReturn(USERNAME_1);
+        when(auditHelper.getCurrentTime()).thenReturn(CREATED_ON);
+        when(geocodeService.getLocationInfo(notNull(Program.class))).thenReturn(createLocationInfo());
+
+        /* Make the call. */
+        toTest.save(input);
+
+        /* Should not blow up because google found the zipcode for us. */
+    }
+
     @Test(expected = ProgramZipCodeRequiredException.class)
     public void testSaveCreateNewNullZipCode() throws Exception {
         Program input = createFilledInProgram();
         input.setId(null);
         input.setZipCode(null);
 
+        LocationInfo locationInfo = createLocationInfo();
+        locationInfo.setZipCode(null);
+
+        /* Train the mocks. */
+        when(organizationService.getById(ORG_ID)).thenReturn(createOrg());
+        when(auditHelper.getCurrentUser()).thenReturn(USERNAME_1);
+        when(auditHelper.getCurrentTime()).thenReturn(CREATED_ON);
+        when(geocodeService.getLocationInfo(notNull(Program.class))).thenReturn(locationInfo);
+
         /* Make the call. */
         toTest.save(input);
+    }
+
+    @Test
+    public void testSaveCreateNewEmptyZipCodeButGoogleFoundIt() throws Exception {
+        Program input = createFilledInProgram();
+        input.setId(null);
+        input.setZipCode("");
+
+        /* Train the mocks. */
+        when(organizationService.getById(ORG_ID)).thenReturn(createOrg());
+        when(auditHelper.getCurrentUser()).thenReturn(USERNAME_1);
+        when(auditHelper.getCurrentTime()).thenReturn(CREATED_ON);
+        when(geocodeService.getLocationInfo(notNull(Program.class))).thenReturn(createLocationInfo());
+
+        /* Make the call. */
+        toTest.save(input);
+
+        /* Should not blow up because google found the zipcode for us. */
     }
 
     @Test(expected = ProgramZipCodeRequiredException.class)
@@ -291,8 +334,35 @@ public class DefaultProgramServiceTest {
         input.setId(null);
         input.setZipCode("");
 
+        LocationInfo locationInfo = createLocationInfo();
+        locationInfo.setZipCode(null);
+
+        /* Train the mocks. */
+        when(organizationService.getById(ORG_ID)).thenReturn(createOrg());
+        when(auditHelper.getCurrentUser()).thenReturn(USERNAME_1);
+        when(auditHelper.getCurrentTime()).thenReturn(CREATED_ON);
+        when(geocodeService.getLocationInfo(notNull(Program.class))).thenReturn(locationInfo);
+
         /* Make the call. */
         toTest.save(input);
+    }
+
+    @Test
+    public void testSaveCreateNewOnlyWhitespaceZipCodeButGoogleFoundIt() throws Exception {
+        Program input = createFilledInProgram();
+        input.setId(null);
+        input.setZipCode(" ");
+
+        /* Train the mocks. */
+        when(organizationService.getById(ORG_ID)).thenReturn(createOrg());
+        when(auditHelper.getCurrentUser()).thenReturn(USERNAME_1);
+        when(auditHelper.getCurrentTime()).thenReturn(CREATED_ON);
+        when(geocodeService.getLocationInfo(notNull(Program.class))).thenReturn(createLocationInfo());
+
+        /* Make the call. */
+        toTest.save(input);
+
+        /* Should not blow up because google found the zipcode for us. */
     }
 
     @Test(expected = ProgramZipCodeRequiredException.class)
@@ -301,8 +371,35 @@ public class DefaultProgramServiceTest {
         input.setId(null);
         input.setZipCode(" ");
 
+        LocationInfo locationInfo = createLocationInfo();
+        locationInfo.setZipCode(null);
+
+        /* Train the mocks. */
+        when(organizationService.getById(ORG_ID)).thenReturn(createOrg());
+        when(auditHelper.getCurrentUser()).thenReturn(USERNAME_1);
+        when(auditHelper.getCurrentTime()).thenReturn(CREATED_ON);
+        when(geocodeService.getLocationInfo(notNull(Program.class))).thenReturn(locationInfo);
+
         /* Make the call. */
         toTest.save(input);
+    }
+
+    @Test
+    public void testSaveCreateNewNullStartYear() throws Exception {
+        Program input = createFilledInProgram();
+        input.setId(null);
+        input.setStartYear(null);
+
+        /* Train the mocks. */
+        when(organizationService.getById(ORG_ID)).thenReturn(createOrg());
+        when(auditHelper.getCurrentUser()).thenReturn(USERNAME_1);
+        when(auditHelper.getCurrentTime()).thenReturn(CREATED_ON);
+        when(geocodeService.getLocationInfo(notNull(Program.class))).thenReturn(createLocationInfo());
+
+        /* Make the call. */
+        toTest.save(input);
+
+        /* Should not blow up.  After receiving some customer data, we discovered that this should be allowed. */
     }
 
     @Test
@@ -336,7 +433,7 @@ public class DefaultProgramServiceTest {
         when(organizationService.getById(ORG_ID)).thenReturn(createOrg());
         when(auditHelper.getCurrentUser()).thenReturn(USERNAME_1);
         when(auditHelper.getCurrentTime()).thenReturn(CREATED_ON);
-        when(geocodeService.getLngLat(notNull(Program.class))).thenReturn(GEO_CODE);
+        when(geocodeService.getLocationInfo(notNull(Program.class))).thenReturn(createLocationInfo());
         when(dao.save(inputWithCreatedAuditFilledIn)).thenReturn(inputWithCreatedAuditFilledIn);
 
         /* Make the call. */
@@ -377,7 +474,7 @@ public class DefaultProgramServiceTest {
         when(organizationService.save(inputOrg)).thenReturn(createOrg());
         when(auditHelper.getCurrentUser()).thenReturn(USERNAME_1);
         when(auditHelper.getCurrentTime()).thenReturn(CREATED_ON);
-        when(geocodeService.getLngLat(notNull(Program.class))).thenReturn(GEO_CODE);
+        when(geocodeService.getLocationInfo(notNull(Program.class))).thenReturn(createLocationInfo());
         when(dao.save(inputWithCreatedAuditFilledIn)).thenReturn(inputWithCreatedAuditFilledIn);
 
         /* Make the call. */
@@ -428,7 +525,7 @@ public class DefaultProgramServiceTest {
         when(dao.findOne(PROGRAM_ID)).thenReturn(oldProgramInDb);
         when(auditHelper.getCurrentUser()).thenReturn(USERNAME_2);
         when(auditHelper.getCurrentTime()).thenReturn(UPDATED_ON);
-        when(geocodeService.getLngLat(notNull(Program.class))).thenReturn(GEO_CODE);
+        when(geocodeService.getLocationInfo(notNull(Program.class))).thenReturn(createLocationInfo());
         when(dao.save(inputWithUpdatedAuditFilledIn)).thenReturn(inputWithUpdatedAuditFilledIn);
 
         /* Make the call. */
@@ -479,7 +576,7 @@ public class DefaultProgramServiceTest {
         when(dao.findOne(PROGRAM_ID)).thenReturn(oldProgramInDb);
         when(auditHelper.getCurrentUser()).thenReturn(USERNAME_2);
         when(auditHelper.getCurrentTime()).thenReturn(UPDATED_ON);
-        when(geocodeService.getLngLat(notNull(Program.class))).thenReturn(GEO_CODE);
+        when(geocodeService.getLocationInfo(notNull(Program.class))).thenReturn(createLocationInfo());
         when(dao.save(inputWithUpdatedAuditFilledIn)).thenReturn(inputWithUpdatedAuditFilledIn);
 
         /* Make the call. */
@@ -496,6 +593,7 @@ public class DefaultProgramServiceTest {
         input.setName(ORG_NAME);
 
         /* Train the mocks. */
+        when(geocodeService.getLocationInfo(notNull(Program.class))).thenReturn(createLocationInfo());
         when(dao.findOne(PROGRAM_ID)).thenReturn(null);
 
         /* Make the call. */


### PR DESCRIPTION
* Removes required from zipcode on program form.
* Changes GeocodeService to offer the zipcode as well as lat-lng.
* Changes ProgramService to use zipcode from google before throwing an error if
  zipcode is missing.
* Updates unit tests.