### PR TITLE
closes #49: Implement authN & authZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ Create a .env file to the top level directory of this project with the PORT to s
 
 ~~~~shell
 PORT=8080
-JDBC_DATABASE_URL='jdbc:postgresql://localhost:5432/hmhb_db'
+JDBC_DATABASE_URL="jdbc:postgresql://localhost:5432/hmhb_db"
+GOOGLE_OAUTH_CLIENT_ID="259324353484-f8u4ltb5qko7fltub68dguhs16ae93nr.apps.googleusercontent.com"
+GOOGLE_OAUTH_CLIENT_SECRET="<secret>"
+HMHB_JWT_SECRET="<also secret>"
 ~~~~
 
 Now you can run the latest code you have built locally with:

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,14 @@ dependencies {
     /* using Moxy for jaxb so we can have CDATA in our xml */
     compile("org.eclipse.persistence:org.eclipse.persistence.moxy:2.6.4")
 
+    /* libraries to call into google for user information */
+    compile("com.google.api-client:google-api-client:1.22.0")
+    compile("com.google.apis:google-api-services-plus:v1-rev455-1.22.0")
+    compile("com.google.apis:google-api-services-gmail:v1-rev48-1.22.0")
+
+    /* libraries for jwt token generation and verification */
+    compile("io.jsonwebtoken:jjwt:0.7.0")
+
     testCompile("junit:junit:4.12")
     testCompile("org.hamcrest:hamcrest-core:1.3")
     testCompile("org.mockito:mockito-all:1.10.19")

--- a/client/package.json
+++ b/client/package.json
@@ -35,6 +35,7 @@
     "karma-firefox-launcher": "~1.0.0",
     "karma-jasmine-html-reporter": "~0.2.2",
     "ngmap": "~1.17.6",
+    "satellizer": "0.14.1",
     "phantomjs-prebuilt": "~2.1.12"
   },
   "engine": "node >= 0.4.1",

--- a/client/src/main/webjar/app.js
+++ b/client/src/main/webjar/app.js
@@ -64,6 +64,7 @@
             "ngMessages",
             "ngResource",
             "ui.router",
+            "healthBam.authentication",
             "healthBam.main",
             "healthBam.map",
             "healthBam.programDetails",

--- a/client/src/main/webjar/authentication/authentication.component.js
+++ b/client/src/main/webjar/authentication/authentication.component.js
@@ -1,0 +1,53 @@
+(function (angular) {
+    "use strict";
+
+    var module = angular.module("healthBam.authentication");
+
+    /**
+     * Controller for the healthBamAuthentication component.
+     * @param $log
+     * @param authenticationService
+     * @constructor
+     */
+    function AuthenticationController(
+        $log,
+        authenticationService
+    ) {
+
+        var auth = this;
+
+        /**
+         * Initializes the controller.
+         */
+        function activate() {
+
+            auth.authenticate = authenticationService.authenticate;
+            auth.isAuthenticated = authenticationService.isAuthenticated;
+            auth.isAdmin = authenticationService.isAdmin;
+            auth.getEmail = authenticationService.getEmail;
+            auth.logout = authenticationService.logout;
+
+            $log.debug("Authentication Controller loaded", auth);
+        }
+
+        /* Run activate when component is loaded. */
+        auth.$onInit = activate;
+    }
+
+    /* Inject dependencies. */
+    AuthenticationController.$inject = [
+        "$log",
+        "authenticationService"
+    ];
+
+    /* Create healthBamAuthentication component. */
+    module.component(
+        "healthBamAuthentication",
+        {
+            templateUrl: "authentication.html",
+            controller: AuthenticationController,
+            controllerAs: "auth"
+        }
+    );
+
+}(window.angular));

--- a/client/src/main/webjar/authentication/authentication.config.js
+++ b/client/src/main/webjar/authentication/authentication.config.js
@@ -1,0 +1,62 @@
+(function (angular) {
+    "use strict";
+
+    var module = angular.module("healthBam.authentication");
+
+    /**
+     * Returns the protocol, host, and port part of our single-page-app's URL.
+     *
+     * Right now, this has to match what the server is sending to google, so it
+     * has to be explicit with the port.
+     */
+    function getUrlPrefix() {
+        /* location.protocol includes the colon */
+        var urlPrefix = location.protocol + "//" + location.hostname,
+            port = location.port;
+
+        if (!port) {
+            /* we have to infer it from the protocol */
+            if (location.protocol === "http:") {
+                port = 80;
+            } else if (location.protocol === "https:") {
+                port = 443;
+            } else {
+                throw new Error("Unknown protocol! " + location.protocol);
+            }
+        }
+
+        return urlPrefix + ":" + port + "/";
+    }
+
+    /**
+     * Configures satellizer's Google Oauth.
+     */
+    function configGoogleOauth(
+        $authProvider
+    ) {
+        var redirectUri = getUrlPrefix() + "views/oauth-callback";
+
+        window.console.log("Registering google oauth with: redirectUri = ", redirectUri);
+
+        $authProvider.google(
+            {
+                /* https://developers.google.com/identity/protocols/OAuth2UserAgent */
+                prompt: "select_account",
+                optionalUrlParams: [
+                    "prompt"
+                ],
+                url: "/auth/google", /* posts to our server */
+                redirectUri: redirectUri, /* redirects to the angular app; this has to match what the server uses */
+                /* TODO: get the clientId and redirectUrl from the server */
+                clientId: "259324353484-f8u4ltb5qko7fltub68dguhs16ae93nr.apps.googleusercontent.com"
+            }
+        );
+    }
+
+    configGoogleOauth.$inject = [
+        "$authProvider"
+    ];
+
+    module.config(configGoogleOauth);
+
+}(window.angular));

--- a/client/src/main/webjar/authentication/authentication.html
+++ b/client/src/main/webjar/authentication/authentication.html
@@ -1,0 +1,26 @@
+<div>
+    <div ng-if="!auth.isAuthenticated()">
+        <button ng-click="auth.authenticate()">
+            Login
+        </button>
+    </div>
+    <div ng-if="auth.isAuthenticated()">
+        <button ng-click="auth.logout()">
+            Logout
+        </button>
+    </div>
+    <div>
+        <span>
+            email:
+        </span>
+        <span ng-bind="auth.getEmail()">
+        </span>
+    </div>
+    <div>
+        <span>
+            admin:
+        </span>
+        <span ng-bind="auth.isAdmin()">
+        </span>
+    </div>
+</div>

--- a/client/src/main/webjar/authentication/authentication.module.js
+++ b/client/src/main/webjar/authentication/authentication.module.js
@@ -1,0 +1,12 @@
+(function (angular) {
+    "use strict";
+
+    angular.module(
+        "healthBam.authentication",
+        [
+            "ngMaterial",
+            "satellizer"
+        ]
+    );
+
+}(window.angular));

--- a/client/src/main/webjar/authentication/authentication.service.js
+++ b/client/src/main/webjar/authentication/authentication.service.js
@@ -1,0 +1,98 @@
+(function (angular) {
+    "use strict";
+
+    var module = angular.module("healthBam.authentication");
+
+    /**
+     * A service to authenticate
+     */
+    function authenticationServiceFactory(
+        $log,
+        $q,
+        $auth
+    ) {
+
+        /**
+         * Pops open satellizer's login prompt.
+         */
+        function authenticate() {
+            $log.debug("authenticate called");
+
+            return $auth.authenticate("google").then(
+                function (response) {
+                    $log.debug("login succeeded", response);
+                    return response;
+                }
+            ).catch(
+                function (response) {
+                    $log.debug("login failed", response);
+                    return $q.reject(response);
+                }
+            );
+        }
+
+        /**
+         * Returns true if the user has a token and it isn't expired.
+         */
+        function isAuthenticated() {
+            return $auth.isAuthenticated();
+        }
+
+        /**
+         * Returns true if the user is logged in and is an admin.
+         */
+        function isAdmin() {
+            if (isAuthenticated()) {
+                return $auth.getPayload().admin;
+            }
+            return false;
+        }
+
+        /**
+         * Returns the user's email or empty string if not logged in.
+         */
+        function getEmail() {
+            if (isAuthenticated()) {
+                return $auth.getPayload().email;
+            }
+            return "";
+        }
+
+        /**
+         * Returns the user's JWT token.
+         */
+        function getToken() {
+            $log.debug("getToken called");
+            return $auth.getToken();
+        }
+
+        /**
+         * Logs the user out by deleting their token from localStorage.
+         */
+        function logout() {
+            $log.debug("logout called");
+            return $auth.logout();
+        }
+
+        return {
+            authenticate: authenticate,
+            isAuthenticated: isAuthenticated,
+            isAdmin: isAdmin,
+            getEmail: getEmail,
+            getToken: getToken,
+            logout: logout
+        };
+    }
+
+    authenticationServiceFactory.$inject = [
+        "$log",
+        "$q",
+        "$auth"
+    ];
+
+    module.factory(
+        "authenticationService",
+        authenticationServiceFactory
+    );
+
+}(window.angular));

--- a/client/src/main/webjar/sidenav/sidenav.html
+++ b/client/src/main/webjar/sidenav/sidenav.html
@@ -5,4 +5,7 @@
 
     <health-bam-map-query-form></health-bam-map-query-form>
 
+    <health-bam-authentication>
+    </health-bam-authentication>
+
 </md-sidenav>

--- a/client/src/test/webjar/karma.conf.js
+++ b/client/src/test/webjar/karma.conf.js
@@ -17,6 +17,7 @@ module.exports = function (config) {
                 "node_modules/angular-ui-router/release/angular-ui-router.js",
                 "node_modules/angular-material/angular-material.js",
                 "node_modules/ngmap/build/scripts/ng-map.js",
+                "node_modules/satellizer/satellizer.js",
                 "src/main/**/*.module.js",
                 "src/main/**/*.js",
                 "src/test/**/*.spec.js"

--- a/config/application.properties
+++ b/config/application.properties
@@ -1,3 +1,11 @@
+# oauth information
+google.oauth.client.id = ${GOOGLE_OAUTH_CLIENT_ID}
+google.oauth.client.secret = ${GOOGLE_OAUTH_CLIENT_SECRET}
+
+# hmhb token information (used for generating jwt tokens)
+hmhb.jwt.domain = hmhb.herokuapp.com
+hmhb.jwt.secret = ${HMHB_JWT_SECRET}
+
 # disabling these until we have an admin login to protect these with (they show sensitive things: db password)
 endpoints.env.enabled = false
 endpoints.configprops.enabled = false

--- a/integration-tests/input-customer-data.jmx
+++ b/integration-tests/input-customer-data.jmx
@@ -11,6 +11,16 @@
       <stringProp name="TestPlan.user_define_classpath"></stringProp>
     </TestPlan>
     <hashTree>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="googleOauthClientId" elementType="Argument">
+            <stringProp name="Argument.name">googleOauthClientId</stringProp>
+            <stringProp name="Argument.value">259324353484-f8u4ltb5qko7fltub68dguhs16ae93nr.apps.googleusercontent.com</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
       <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
         <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
           <collectionProp name="Arguments.arguments"/>
@@ -35,6 +45,10 @@
             <stringProp name="Header.name">Accept</stringProp>
             <stringProp name="Header.value">application/json</stringProp>
           </elementProp>
+          <elementProp name="" elementType="Header">
+            <stringProp name="Header.name">Authorization</stringProp>
+            <stringProp name="Header.value">Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiYXVkIjoiaG1oYi5oZXJva3VhcHAuY29tIiwiaXNzIjoiaG1oYi5oZXJva3VhcHAuY29tIiwiYWRtaW4iOnRydWUsImV4cCI6MTQ3Nzg3Njg3MywiaWF0IjoxNDc3MjcyMDczLCJlbWFpbCI6ImpvaG4ucnlhbi5iYXJkQGdtYWlsLmNvbSJ9.hT8L3A0RVswzCbiGOi392tk5Ougwkjs8N1ff5N0J-98</stringProp>
+          </elementProp>
         </collectionProp>
       </HeaderManager>
       <hashTree/>
@@ -53,10 +67,112 @@
         <stringProp name="ThreadGroup.delay"></stringProp>
       </ThreadGroup>
       <hashTree>
+        <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="Google Oauth Request" enabled="false"/>
+        <hashTree>
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="promptForRequestToken" enabled="true">
+            <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+              <collectionProp name="Arguments.arguments">
+                <elementProp name="response_type" elementType="HTTPArgument">
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <stringProp name="Argument.value">code</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                  <stringProp name="Argument.name">response_type</stringProp>
+                </elementProp>
+                <elementProp name="client_id" elementType="HTTPArgument">
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <stringProp name="Argument.value">${googleOauthClientId}</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                  <stringProp name="Argument.name">client_id</stringProp>
+                </elementProp>
+                <elementProp name="redirect_uri" elementType="HTTPArgument">
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <stringProp name="Argument.value">http://hmhb.herokuapp.com/views/oauth-callback</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                  <stringProp name="Argument.name">redirect_uri</stringProp>
+                </elementProp>
+                <elementProp name="scope" elementType="HTTPArgument">
+                  <boolProp name="HTTPArgument.always_encode">true</boolProp>
+                  <stringProp name="Argument.value">email profile</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                  <stringProp name="Argument.name">scope</stringProp>
+                </elementProp>
+                <elementProp name="prompt" elementType="HTTPArgument">
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <stringProp name="Argument.value">select_account</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                  <stringProp name="Argument.name">prompt</stringProp>
+                </elementProp>
+              </collectionProp>
+            </elementProp>
+            <stringProp name="HTTPSampler.domain">accounts.google.com</stringProp>
+            <stringProp name="HTTPSampler.port">443</stringProp>
+            <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+            <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            <stringProp name="HTTPSampler.protocol">https</stringProp>
+            <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+            <stringProp name="HTTPSampler.path">/o/oauth2/v2/auth</stringProp>
+            <stringProp name="HTTPSampler.method">GET</stringProp>
+            <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+            <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+            <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+            <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+            <boolProp name="HTTPSampler.monitor">false</boolProp>
+            <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          </HTTPSamplerProxy>
+          <hashTree>
+            <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
+              <collectionProp name="Asserion.test_strings">
+                <stringProp name="49586">200</stringProp>
+              </collectionProp>
+              <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
+              <boolProp name="Assertion.assume_success">false</boolProp>
+              <intProp name="Assertion.test_type">8</intProp>
+            </ResponseAssertion>
+            <hashTree/>
+            <JSR223Assertion guiclass="TestBeanGUI" testclass="JSR223Assertion" testname="JSR223 Assertion" enabled="true">
+              <stringProp name="cacheKey"></stringProp>
+              <stringProp name="filename"></stringProp>
+              <stringProp name="parameters"></stringProp>
+              <stringProp name="script">function setFailure(message) {
+	prev.setSuccessful(false);
+	prev.setResponseMessage(prev.getResponseMessage() + message);
+}
+
+function assert(success, message) {
+	if (!success) {
+		setFailure(message);
+	}
+}
+
+function assertEquals(actual, expected) {
+	var actualStr = JSON.stringify(actual),
+	    expectedStr = JSON.stringify(expected);
+	assert(
+		actualStr === expectedStr,
+		&quot;\n\nNOT EQUAL: actual = &quot; + actualStr + &quot;\n               expected = &quot; + expectedStr
+	);
+}
+
+var responseString = SampleResult.getResponseDataAsString();
+var responseData = JSON.parse(responseString);
+
+assert(responseData.id, &quot;id was not set!&quot;);
+
+vars.put(&quot;orgId&quot;, responseData.id);
+</stringProp>
+              <stringProp name="scriptLanguage">javascript</stringProp>
+            </JSR223Assertion>
+            <hashTree/>
+          </hashTree>
+        </hashTree>
         <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="Create Org" enabled="false"/>
         <hashTree>
           <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="createNewOrg" enabled="true">
-            <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
             <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
               <collectionProp name="Arguments.arguments">
                 <elementProp name="" elementType="HTTPArgument">
@@ -72,6 +188,7 @@
                 </elementProp>
               </collectionProp>
             </elementProp>
+            <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
             <stringProp name="HTTPSampler.domain"></stringProp>
             <stringProp name="HTTPSampler.port"></stringProp>
             <stringProp name="HTTPSampler.connect_timeout"></stringProp>
@@ -230,6 +347,15 @@ vars.put(&quot;programId&quot;, responseData.id);
             <hashTree/>
           </hashTree>
         </hashTree>
+        <ModuleController guiclass="ModuleControllerGui" testclass="ModuleController" testname="Google Oauth Request" enabled="false">
+          <collectionProp name="ModuleController.node_path">
+            <stringProp name="-1227702913">WorkBench</stringProp>
+            <stringProp name="764597751">Test Plan</stringProp>
+            <stringProp name="-1948168983">Thread Group</stringProp>
+            <stringProp name="305515583">Google Oauth Request</stringProp>
+          </collectionProp>
+        </ModuleController>
+        <hashTree/>
         <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="Create HMHB Prenatal Education Program" enabled="true"/>
         <hashTree>
           <DebugSampler guiclass="TestBeanGUI" testclass="DebugSampler" testname="-- Begin HMHB Prenatal Education Data --" enabled="true">

--- a/src/main/java/org/hmhb/authentication/AuthenticationController.java
+++ b/src/main/java/org/hmhb/authentication/AuthenticationController.java
@@ -1,0 +1,45 @@
+package org.hmhb.authentication;
+
+import javax.annotation.Nonnull;
+
+import com.codahale.metrics.annotation.Timed;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import static java.util.Objects.requireNonNull;
+
+@RestController
+public class AuthenticationController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuthenticationController.class);
+
+    private final AuthenticationService service;
+
+    @Autowired
+    public AuthenticationController(
+            @Nonnull AuthenticationService service
+    ) {
+        this.service = requireNonNull(service, "service cannot be null");
+    }
+
+    @Timed
+    @RequestMapping(
+            method = RequestMethod.POST,
+            produces = MediaType.APPLICATION_JSON_VALUE,
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            path = "/auth/google"
+    )
+    public TokenResponse create(
+            @RequestBody GoogleOauthAccessRequestInfo request
+    ) {
+        LOGGER.debug("authenticate called: request={}", request);
+        return service.authenticate(request);
+    }
+
+}

--- a/src/main/java/org/hmhb/authentication/AuthenticationFilter.java
+++ b/src/main/java/org/hmhb/authentication/AuthenticationFilter.java
@@ -1,0 +1,64 @@
+package org.hmhb.authentication;
+
+import javax.annotation.Nonnull;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.Objects.requireNonNull;
+
+public class AuthenticationFilter implements Filter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuthenticationFilter.class);
+
+    private final JwtAuthenticationService authenticationService;
+
+    public AuthenticationFilter(
+            @Nonnull JwtAuthenticationService authenticationService
+    ) {
+        this.authenticationService = requireNonNull(authenticationService, "authenticationService cannot be null");
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        LOGGER.info("init called");
+    }
+
+    @Override
+    public void doFilter(
+            ServletRequest servletRequest,
+            ServletResponse servletResponse,
+            FilterChain chain
+    ) throws IOException, ServletException {
+        LOGGER.info("doFilter called");
+
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        try {
+            authenticationService.validateAuthentication(request);
+        } catch (Exception e) {
+            LOGGER.error("Authentication failure!", e);
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy() {
+        LOGGER.info("destroy called");
+    }
+
+}

--- a/src/main/java/org/hmhb/authentication/AuthenticationService.java
+++ b/src/main/java/org/hmhb/authentication/AuthenticationService.java
@@ -1,0 +1,11 @@
+package org.hmhb.authentication;
+
+import javax.annotation.Nonnull;
+
+public interface AuthenticationService {
+
+    TokenResponse authenticate(
+            @Nonnull GoogleOauthAccessRequestInfo request
+    );
+
+}

--- a/src/main/java/org/hmhb/authentication/DefaultAuthenticationService.java
+++ b/src/main/java/org/hmhb/authentication/DefaultAuthenticationService.java
@@ -1,0 +1,103 @@
+package org.hmhb.authentication;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
+import org.hmhb.exception.authentication.ClientIdMismatchException;
+import org.hmhb.exception.oauth.GoogleOauthException;
+import org.hmhb.exception.user.UserNotFoundException;
+import org.hmhb.oauth.GoogleOauthService;
+import org.hmhb.user.HmhbUser;
+import org.hmhb.user.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+
+import static java.util.Objects.requireNonNull;
+
+@Service
+public class DefaultAuthenticationService implements AuthenticationService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAuthenticationService.class);
+
+    private final Environment environment;
+    private final GoogleOauthService googleOauthService;
+    private final JwtAuthenticationService jwtAuthenticationService;
+    private final UserService userService;
+
+    @Autowired
+    public DefaultAuthenticationService(
+            @Nonnull Environment environment,
+            @Nonnull GoogleOauthService googleOauthService,
+            @Nonnull JwtAuthenticationService jwtAuthenticationService,
+            @Nonnull UserService userService
+    ) {
+        this.environment = requireNonNull(environment, "environment cannot be null");
+        this.googleOauthService = requireNonNull(googleOauthService, "googleOauthService cannot be null");
+        this.jwtAuthenticationService = requireNonNull(jwtAuthenticationService, "jwtAuthenticationService cannot be null");
+        this.userService = requireNonNull(userService, "userService cannot be null");
+    }
+
+    @Override
+    public TokenResponse authenticate(
+            @Nonnull GoogleOauthAccessRequestInfo request
+    ) {
+        LOGGER.debug("authenticate called: request={}", request);
+        requireNonNull(request, "request cannot be null");
+
+        String email;
+
+        String clientId = environment.getProperty("google.oauth.client.id");
+        String clientSecret = environment.getProperty("google.oauth.client.secret");
+
+        if (!clientId.equals(request.getClientId())) {
+            throw new ClientIdMismatchException(
+                    request.getClientId(),
+                    clientId
+            );
+        }
+
+        LOGGER.debug(
+                "Calling into google: clientId={}, code={}, redirectUrl={}",
+                request.getClientId(),
+                request.getCode(),
+                request.getRedirectUri()
+        );
+
+        GoogleTokenResponse googleTokenResponse = googleOauthService.getTokenResponse(
+                request.getClientId(),
+                clientSecret,
+                request.getCode(),
+                request.getRedirectUri()
+        );
+
+        try {
+            GoogleIdToken idToken = googleTokenResponse.parseIdToken();
+            email = idToken.getPayload().getEmail();
+            LOGGER.debug("successfully called into google: email={}", email);
+        } catch (IOException e) {
+            throw new GoogleOauthException("Failed to parse google id token!", e);
+        }
+
+        HmhbUser user;
+
+        try {
+            user = userService.getUserByEmail(email);
+        } catch (UserNotFoundException e) {
+            user = userService.provisionNewUser(email);
+        }
+
+        TokenResponse tokenResponse = new TokenResponse(
+                jwtAuthenticationService.generateJwtToken(user)
+        );
+
+        LOGGER.info("tokenResponse: {}", tokenResponse);
+        return tokenResponse;
+    }
+
+}

--- a/src/main/java/org/hmhb/authentication/DefaultJwtAuthenticationService.java
+++ b/src/main/java/org/hmhb/authentication/DefaultJwtAuthenticationService.java
@@ -1,0 +1,178 @@
+package org.hmhb.authentication;
+
+import javax.annotation.Nonnull;
+import javax.crypto.spec.SecretKeySpec;
+import javax.servlet.http.HttpServletRequest;
+import javax.xml.bind.DatatypeConverter;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.hmhb.exception.authentication.AuthHeaderHasTooManyPartsException;
+import org.hmhb.exception.authentication.AuthHeaderMissingTokenException;
+import org.hmhb.exception.authentication.AuthHeaderUnknownException;
+import org.hmhb.exception.authentication.JwtTokenExpiredException;
+import org.hmhb.exception.authentication.JwtTokenNotActiveYetException;
+import org.hmhb.exception.authentication.JwtTokenNotSignedException;
+import org.hmhb.user.HmhbUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+
+import static java.util.Objects.requireNonNull;
+
+@Service
+public class DefaultJwtAuthenticationService implements JwtAuthenticationService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAuthenticationService.class);
+
+    private final Environment environment;
+
+    @Autowired
+    public DefaultJwtAuthenticationService(
+            @Nonnull Environment environment
+    ) {
+        this.environment = requireNonNull(environment, "environment cannot be null");
+    }
+
+    private String getDomain() {
+        return environment.getProperty("hmhb.jwt.domain");
+    }
+
+    private String getSecret() {
+        return environment.getProperty("hmhb.jwt.secret");
+    }
+
+    private Date getTokenExpirationDate() {
+        /* one week */
+        return new Date(System.currentTimeMillis() + 7 * 24 * 60 * 60 * 1000);
+    }
+
+    @Override
+    public String generateJwtToken(
+            @Nonnull HmhbUser user
+    ) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("admin", user.isAdmin());
+        claims.put("email", user.getEmail());
+        claims.put("userId", user.getId());
+
+        String domainId = getDomain();
+        String secret = getSecret();
+
+        String token = Jwts.builder()
+                /* you must set claims before the others or else setClaims will clear your other properties */
+                .setClaims(claims)
+                .setIssuedAt(new Date())
+                .setExpiration(getTokenExpirationDate())
+                .setSubject("" + user.getId())
+                .setAudience(domainId)
+                .setIssuer(domainId)
+                .signWith(SignatureAlgorithm.HS256, secret)
+                .compact();
+
+        LOGGER.debug("token: {}", token);
+
+        return token;
+    }
+
+    @Override
+    public void validateAuthentication(
+            @Nonnull HttpServletRequest request
+    ) {
+        requireNonNull(request, "request cannot be null");
+
+        String authHeader = request.getHeader("Authorization");
+
+        LOGGER.debug("processing authentication: header={}", authHeader);
+
+        if (authHeader != null) {
+
+            String[] authHeaderInfo = authHeader.split("[ ]");
+
+            if (authHeaderInfo.length < 2) {
+                throw new AuthHeaderMissingTokenException(authHeader);
+            }
+
+            if (authHeaderInfo.length > 2) {
+                throw new AuthHeaderHasTooManyPartsException(authHeader);
+            }
+
+            if (!"Bearer".equals(authHeaderInfo[0])) {
+                throw new AuthHeaderUnknownException(authHeader);
+            }
+
+            String authToken = authHeaderInfo[1];
+
+            if (!Jwts.parser().isSigned(authToken)) {
+                throw new JwtTokenNotSignedException();
+            }
+
+            String domainId = getDomain();
+            String secret = getSecret();
+
+            byte[] keyBytes = DatatypeConverter.parseBase64Binary(secret);
+            /* I'm using setSigningKey with the SecretKeySpec so I can enforce which algorithm to use. */
+            SecretKeySpec secretKey = new SecretKeySpec(keyBytes, SignatureAlgorithm.HS256.getJcaName());
+
+            LOGGER.debug("authHeader is: {}", authHeader);
+            LOGGER.debug("authToken is: {}", authToken);
+
+            Claims claims = Jwts.parser()
+                    .requireAudience(domainId)
+                    .requireIssuer(domainId)
+                    .setSigningKey(secretKey)
+                    .parseClaimsJws(authToken)
+                    .getBody();
+
+            String username = claims.getSubject();
+            Date issuedAt = claims.getIssuedAt();
+            Date expirationDate = claims.getExpiration();
+            String issuer = claims.getIssuer();
+            String audience = claims.getAudience();
+            boolean admin = claims.get("admin", Boolean.class);
+            String email = claims.get("email", String.class);
+            Long userId = claims.get("userId", Integer.class).longValue();
+
+            Date now = new Date();
+
+            if (issuedAt.after(now)) {
+                throw new JwtTokenNotActiveYetException(issuedAt);
+            }
+
+            if (expirationDate.before(now)) {
+                throw new JwtTokenExpiredException(expirationDate);
+            }
+
+            LOGGER.debug(
+                    "token accepted, standard info: issuer={}, audience={}, username={}, issuedAt={}, expiresOn={}",
+                    issuer,
+                    audience,
+                    username,
+                    issuedAt,
+                    expirationDate
+            );
+
+            LOGGER.debug(
+                    "token accepted, custom info: admin={}, email={}, userId={}",
+                    admin,
+                    email,
+                    userId
+            );
+
+            HmhbUser user = new HmhbUser();
+            user.setAdmin(admin);
+            user.setEmail(email);
+            user.setId(userId);
+
+            request.setAttribute("loggedInUser", user);
+        }
+    }
+
+}

--- a/src/main/java/org/hmhb/authentication/GoogleOauthAccessRequestInfo.java
+++ b/src/main/java/org/hmhb/authentication/GoogleOauthAccessRequestInfo.java
@@ -1,0 +1,61 @@
+package org.hmhb.authentication;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+public class GoogleOauthAccessRequestInfo {
+
+    private String clientId;
+    private String code;
+    private String redirectUri;
+    private String state;
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getRedirectUri() {
+        return redirectUri;
+    }
+
+    public void setRedirectUri(String redirectUri) {
+        this.redirectUri = redirectUri;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+}

--- a/src/main/java/org/hmhb/authentication/JwtAuthenticationService.java
+++ b/src/main/java/org/hmhb/authentication/JwtAuthenticationService.java
@@ -1,0 +1,18 @@
+package org.hmhb.authentication;
+
+import javax.annotation.Nonnull;
+import javax.servlet.http.HttpServletRequest;
+
+import org.hmhb.user.HmhbUser;
+
+public interface JwtAuthenticationService {
+
+    String generateJwtToken(
+            @Nonnull HmhbUser user
+    );
+
+    void validateAuthentication(
+            @Nonnull HttpServletRequest request
+    );
+
+}

--- a/src/main/java/org/hmhb/authentication/TokenResponse.java
+++ b/src/main/java/org/hmhb/authentication/TokenResponse.java
@@ -1,0 +1,42 @@
+package org.hmhb.authentication;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class TokenResponse {
+
+    private final String token;
+
+    public TokenResponse(
+            @Nonnull String token
+    ) {
+        this.token = requireNonNull(token, "token cannot be null");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+}

--- a/src/main/java/org/hmhb/authorization/AuthorizationService.java
+++ b/src/main/java/org/hmhb/authorization/AuthorizationService.java
@@ -1,0 +1,9 @@
+package org.hmhb.authorization;
+
+public interface AuthorizationService {
+
+    boolean isLoggedIn();
+
+    boolean isAdmin();
+
+}

--- a/src/main/java/org/hmhb/authorization/DefaultAuthorizationService.java
+++ b/src/main/java/org/hmhb/authorization/DefaultAuthorizationService.java
@@ -1,0 +1,61 @@
+package org.hmhb.authorization;
+
+import javax.annotation.Nonnull;
+import javax.servlet.http.HttpServletRequest;
+
+import org.hmhb.user.HmhbUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import static java.util.Objects.requireNonNull;
+
+@Service
+public class DefaultAuthorizationService implements AuthorizationService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAuthorizationService.class);
+
+    private final HttpServletRequest request;
+
+    @Autowired
+    public DefaultAuthorizationService(
+            @Nonnull HttpServletRequest request
+    ) {
+        this.request = requireNonNull(request, "request cannot be null");
+    }
+
+    private HmhbUser getLoggedInUser() {
+        return (HmhbUser) request.getAttribute("loggedInUser");
+    }
+
+    @Override
+    public boolean isLoggedIn() {
+        LOGGER.debug("isLoggedIn called");
+
+        HmhbUser loggedInUser = getLoggedInUser();
+        LOGGER.debug("currently logged in user: loggedInUser={}", loggedInUser);
+
+        boolean isLoggedIn = loggedInUser != null;
+        LOGGER.debug("isLoggedIn=={}", isLoggedIn);
+
+        return isLoggedIn;
+    }
+
+    @Override
+    public boolean isAdmin() {
+        LOGGER.debug("isAdmin called");
+
+        HmhbUser loggedInUser = getLoggedInUser();
+        boolean isAdmin = false;
+
+        if (loggedInUser != null) {
+            isAdmin = loggedInUser.isAdmin();
+        }
+
+        LOGGER.debug("currently logged in user: isAdmin={}", isAdmin);
+
+        return isAdmin;
+    }
+
+}

--- a/src/main/java/org/hmhb/config/WebConfig.java
+++ b/src/main/java/org/hmhb/config/WebConfig.java
@@ -1,0 +1,34 @@
+package org.hmhb.config;
+
+import javax.annotation.Nonnull;
+import javax.servlet.Filter;
+
+import org.hmhb.authentication.AuthenticationFilter;
+import org.hmhb.authentication.JwtAuthenticationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static java.util.Objects.requireNonNull;
+
+@Configuration
+public class WebConfig {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("WebConfig.AuthFilter");
+    private final JwtAuthenticationService jwtAuthenticationService;
+
+    @Autowired
+    public WebConfig(
+            @Nonnull JwtAuthenticationService jwtAuthenticationService
+    ) {
+        this.jwtAuthenticationService = requireNonNull(jwtAuthenticationService, "jwtAuthenticationService cannot be null");
+    }
+
+    @Bean
+    public Filter provideAuthenticationFilter() {
+        return new AuthenticationFilter(jwtAuthenticationService);
+    }
+
+}

--- a/src/main/java/org/hmhb/exception/authentication/AuthHeaderHasTooManyPartsException.java
+++ b/src/main/java/org/hmhb/exception/authentication/AuthHeaderHasTooManyPartsException.java
@@ -1,0 +1,15 @@
+package org.hmhb.exception.authentication;
+
+import org.hmhb.exception.NotAuthorizedException;
+
+/**
+ * An exception for an unknown authentication header due to having too many
+ * tokens.  Our jwt authentication understands "Bearer token".
+ */
+public class AuthHeaderHasTooManyPartsException extends NotAuthorizedException {
+
+    public AuthHeaderHasTooManyPartsException(String authHeader) {
+        super("Invalid authorization header! " + authHeader);
+    }
+
+}

--- a/src/main/java/org/hmhb/exception/authentication/AuthHeaderMissingTokenException.java
+++ b/src/main/java/org/hmhb/exception/authentication/AuthHeaderMissingTokenException.java
@@ -1,0 +1,15 @@
+package org.hmhb.exception.authentication;
+
+import org.hmhb.exception.NotAuthorizedException;
+
+/**
+ * An exception for an unknown authentication header due to not having a
+ * token.  Our jwt authentication understands "Bearer token".
+ */
+public class AuthHeaderMissingTokenException extends NotAuthorizedException {
+
+    public AuthHeaderMissingTokenException(String authHeader) {
+        super("Authorization header is missing token! " + authHeader);
+    }
+
+}

--- a/src/main/java/org/hmhb/exception/authentication/AuthHeaderUnknownException.java
+++ b/src/main/java/org/hmhb/exception/authentication/AuthHeaderUnknownException.java
@@ -1,0 +1,15 @@
+package org.hmhb.exception.authentication;
+
+import org.hmhb.exception.NotAuthorizedException;
+
+/**
+ * An exception for an unknown authentication header.  Our jwt authentication
+ * understands "Bearer token".
+ */
+public class AuthHeaderUnknownException extends NotAuthorizedException {
+
+    public AuthHeaderUnknownException(String authHeader) {
+        super("Unknown authorization header! " + authHeader);
+    }
+
+}

--- a/src/main/java/org/hmhb/exception/authentication/ClientIdMismatchException.java
+++ b/src/main/java/org/hmhb/exception/authentication/ClientIdMismatchException.java
@@ -1,0 +1,25 @@
+package org.hmhb.exception.authentication;
+
+import org.hmhb.exception.NotAuthorizedException;
+
+/**
+ * Exception thrown when the client's passed in google-oauth-client-id doesn't
+ * match what is configured.  The client's clientId should have ultimately came
+ * from the server, so this indicates a bug in the code, or someone tampering
+ * with things.
+ */
+public class ClientIdMismatchException extends NotAuthorizedException {
+
+    public ClientIdMismatchException(
+            String requestClientId,
+            String configuredClientId
+    ) {
+        super(
+                "Unexpected client ID! request clientId="
+                + requestClientId
+                + ", configured clientId="
+                + configuredClientId
+        );
+    }
+
+}

--- a/src/main/java/org/hmhb/exception/authentication/JwtTokenExpiredException.java
+++ b/src/main/java/org/hmhb/exception/authentication/JwtTokenExpiredException.java
@@ -1,0 +1,17 @@
+package org.hmhb.exception.authentication;
+
+import java.util.Date;
+
+import org.hmhb.exception.NotAuthorizedException;
+
+/**
+ * An exception to indicate that the JWT token is expired and should not be
+ * honored.
+ */
+public class JwtTokenExpiredException extends NotAuthorizedException {
+
+    public JwtTokenExpiredException(Date expiredOn) {
+        super("JWT token is expired! expiredOn=" + expiredOn);
+    }
+
+}

--- a/src/main/java/org/hmhb/exception/authentication/JwtTokenNotActiveYetException.java
+++ b/src/main/java/org/hmhb/exception/authentication/JwtTokenNotActiveYetException.java
@@ -1,0 +1,17 @@
+package org.hmhb.exception.authentication;
+
+import java.util.Date;
+
+import org.hmhb.exception.NotAuthorizedException;
+
+/**
+ * An exception to indicate that a JWT token isn't valid yet (issuedAt) and
+ * shouldn't be honored.
+ */
+public class JwtTokenNotActiveYetException extends NotAuthorizedException {
+
+    public JwtTokenNotActiveYetException(Date issuedAt) {
+        super("JWT token isn't active yet! issuedAt=" + issuedAt);
+    }
+
+}

--- a/src/main/java/org/hmhb/exception/authentication/JwtTokenNotSignedException.java
+++ b/src/main/java/org/hmhb/exception/authentication/JwtTokenNotSignedException.java
@@ -1,0 +1,15 @@
+package org.hmhb.exception.authentication;
+
+import org.hmhb.exception.NotAuthorizedException;
+
+/**
+ * An exception to indicate that the JWT token wasn't signed and cannot be
+ * trusted.
+ */
+public class JwtTokenNotSignedException extends NotAuthorizedException {
+
+    public JwtTokenNotSignedException() {
+        super("JWT is not signed, do not trust it!");
+    }
+
+}

--- a/src/main/java/org/hmhb/exception/oauth/GoogleOauthException.java
+++ b/src/main/java/org/hmhb/exception/oauth/GoogleOauthException.java
@@ -1,0 +1,18 @@
+package org.hmhb.exception.oauth;
+
+import org.hmhb.exception.NotAuthorizedException;
+
+/**
+ * Exception for when something went wrong when calling into google for
+ * information.
+ */
+public class GoogleOauthException extends NotAuthorizedException {
+
+    public GoogleOauthException(
+            String message,
+            Throwable causedBy
+    ) {
+        super(message, causedBy);
+    }
+
+}

--- a/src/main/java/org/hmhb/exception/organization/OnlyAdminCanDeleteOrgException.java
+++ b/src/main/java/org/hmhb/exception/organization/OnlyAdminCanDeleteOrgException.java
@@ -1,0 +1,6 @@
+package org.hmhb.exception.organization;
+
+import org.hmhb.exception.NotAuthorizedException;
+
+public class OnlyAdminCanDeleteOrgException extends NotAuthorizedException {
+}

--- a/src/main/java/org/hmhb/exception/organization/OnlyAdminCanUpdateOrgException.java
+++ b/src/main/java/org/hmhb/exception/organization/OnlyAdminCanUpdateOrgException.java
@@ -1,0 +1,6 @@
+package org.hmhb.exception.organization;
+
+import org.hmhb.exception.NotAuthorizedException;
+
+public class OnlyAdminCanUpdateOrgException extends NotAuthorizedException {
+}

--- a/src/main/java/org/hmhb/exception/program/OnlyAdminCanDeleteProgramException.java
+++ b/src/main/java/org/hmhb/exception/program/OnlyAdminCanDeleteProgramException.java
@@ -1,0 +1,6 @@
+package org.hmhb.exception.program;
+
+import org.hmhb.exception.NotAuthorizedException;
+
+public class OnlyAdminCanDeleteProgramException extends NotAuthorizedException {
+}

--- a/src/main/java/org/hmhb/exception/program/OnlyAdminCanSaveProgramException.java
+++ b/src/main/java/org/hmhb/exception/program/OnlyAdminCanSaveProgramException.java
@@ -1,0 +1,6 @@
+package org.hmhb.exception.program;
+
+import org.hmhb.exception.NotAuthorizedException;
+
+public class OnlyAdminCanSaveProgramException extends NotAuthorizedException {
+}

--- a/src/main/java/org/hmhb/exception/user/UserNotFoundException.java
+++ b/src/main/java/org/hmhb/exception/user/UserNotFoundException.java
@@ -1,0 +1,19 @@
+package org.hmhb.exception.user;
+
+import org.hmhb.exception.NotFoundException;
+import org.hmhb.user.HmhbUser;
+
+/**
+ * Exception thrown when a {@link HmhbUser} cannot be found.
+ */
+public class UserNotFoundException extends NotFoundException {
+
+    public UserNotFoundException(String email) {
+        super("User wasn't found: email=" + email);
+    }
+
+    public UserNotFoundException(Long id) {
+        super("User wasn't found: id=" + id);
+    }
+
+}

--- a/src/main/java/org/hmhb/oauth/DefaultGoogleOauthService.java
+++ b/src/main/java/org/hmhb/oauth/DefaultGoogleOauthService.java
@@ -1,0 +1,42 @@
+package org.hmhb.oauth;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeTokenRequest;
+import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import org.hmhb.exception.oauth.GoogleOauthException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DefaultGoogleOauthService implements GoogleOauthService {
+
+    @Override
+    public GoogleTokenResponse getTokenResponse(
+            @Nonnull String clientId,
+            @Nonnull String clientSecret,
+            @Nonnull String code,
+            @Nonnull String redirectUri
+    ) {
+
+        try {
+
+            return new GoogleAuthorizationCodeTokenRequest(
+                    new NetHttpTransport(),
+                    new JacksonFactory(),
+                    clientId,
+                    clientSecret,
+                    code,
+                    redirectUri
+            ).execute();
+
+        } catch (IOException e) {
+            throw new GoogleOauthException("Failed to call into google for token!", e);
+        }
+
+    }
+
+}

--- a/src/main/java/org/hmhb/oauth/GoogleOauthService.java
+++ b/src/main/java/org/hmhb/oauth/GoogleOauthService.java
@@ -1,0 +1,16 @@
+package org.hmhb.oauth;
+
+import javax.annotation.Nonnull;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
+
+public interface GoogleOauthService {
+
+    GoogleTokenResponse getTokenResponse(
+            @Nonnull String clientId,
+            @Nonnull String clientSecret,
+            @Nonnull String code,
+            @Nonnull String redirectUri
+    );
+
+}

--- a/src/main/java/org/hmhb/user/DefaultUserService.java
+++ b/src/main/java/org/hmhb/user/DefaultUserService.java
@@ -1,0 +1,57 @@
+package org.hmhb.user;
+
+import javax.annotation.Nonnull;
+
+import org.hmhb.exception.user.UserNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import static java.util.Objects.requireNonNull;
+
+@Service
+public class DefaultUserService implements UserService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultUserService.class);
+
+    private final UserDao dao;
+
+    @Autowired
+    public DefaultUserService(
+            @Nonnull UserDao dao
+    ) {
+        this.dao = requireNonNull(dao, "dao cannot be null");
+    }
+
+    @Override
+    public HmhbUser getUserByEmail(
+            @Nonnull String email
+    ) {
+        LOGGER.debug("getUserByEmail called: email={}", email);
+        requireNonNull(email, "email cannot be null");
+
+        HmhbUser user = dao.findByEmail(email);
+
+        if (user == null) {
+            throw new UserNotFoundException(email);
+        }
+
+        return user;
+    }
+
+    @Override
+    public HmhbUser provisionNewUser(
+            @Nonnull String email
+    ) {
+        LOGGER.debug("provisionNewUser called: email={}", email);
+        requireNonNull(email, "email cannot be null");
+
+        HmhbUser user = new HmhbUser();
+        user.setAdmin(false);
+        user.setEmail(email);
+
+        return dao.save(user);
+    }
+
+}

--- a/src/main/java/org/hmhb/user/HmhbUser.java
+++ b/src/main/java/org/hmhb/user/HmhbUser.java
@@ -1,0 +1,65 @@
+package org.hmhb.user;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.validation.constraints.NotNull;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+@Entity
+public class HmhbUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String email;
+
+    @NotNull
+    private boolean isAdmin;
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public boolean isAdmin() {
+        return isAdmin;
+    }
+
+    public void setAdmin(boolean admin) {
+        isAdmin = admin;
+    }
+
+}

--- a/src/main/java/org/hmhb/user/UserDao.java
+++ b/src/main/java/org/hmhb/user/UserDao.java
@@ -1,0 +1,9 @@
+package org.hmhb.user;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface UserDao extends CrudRepository<HmhbUser, Long> {
+
+    HmhbUser findByEmail(String email);
+
+}

--- a/src/main/java/org/hmhb/user/UserService.java
+++ b/src/main/java/org/hmhb/user/UserService.java
@@ -1,0 +1,15 @@
+package org.hmhb.user;
+
+import javax.annotation.Nonnull;
+
+public interface UserService {
+
+    HmhbUser getUserByEmail(
+            @Nonnull String email
+    );
+
+    HmhbUser provisionNewUser(
+            @Nonnull String email
+    );
+
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,6 +1,38 @@
 -- noinspection SqlNoDataSourceInspectionForFile
 
 /**********************************
+ * Begin Users.
+ **********************************/
+INSERT INTO hmhb_user (
+    email,
+    is_admin
+) VALUES (
+    'john.ryan.bard@gmail.com',
+    TRUE
+);
+
+INSERT INTO hmhb_user (
+    email,
+    is_admin
+) VALUES (
+    'mckoon@gmail.com',
+    TRUE
+);
+
+INSERT INTO hmhb_user (
+    email,
+    is_admin
+) VALUES (
+    'jlgett@gmail.com',
+    TRUE
+);
+/**********************************
+ * End Users.
+ **********************************/
+
+
+
+/**********************************
  * Begin Organizations.
  **********************************/
 INSERT INTO organization (

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -4,8 +4,15 @@ DROP TABLE IF EXISTS program_program_area;
 DROP TABLE IF EXISTS program_county;
 DROP TABLE IF EXISTS program;
 DROP TABLE IF EXISTS program_area;
-DROP TABLE IF EXISTS organization;
 DROP TABLE IF EXISTS county;
+DROP TABLE IF EXISTS organization;
+DROP TABLE IF EXISTS hmhb_user;
+
+CREATE TABLE hmhb_user (
+    id BIGSERIAL PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    is_admin BOOLEAN NOT NULL
+);
 
 CREATE TABLE organization (
     id BIGSERIAL PRIMARY KEY,
@@ -18,6 +25,22 @@ CREATE TABLE organization (
     created_by TEXT NOT NULL,
     updated_on DATE,
     updated_by TEXT
+);
+
+CREATE TABLE county (
+    id BIGSERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    state TEXT NOT NULL,
+    outer_boundary1 TEXT NOT NULL,
+    inner_boundary1 TEXT,
+    outer_boundary2 TEXT,
+    outer_boundary3 TEXT,
+    UNIQUE (name, state)
+);
+
+CREATE TABLE program_area (
+    id BIGSERIAL PRIMARY KEY,
+    name TEXT NOT NULL
 );
 
 CREATE TABLE program (
@@ -43,22 +66,6 @@ CREATE TABLE program (
     updated_on DATE,
     updated_by TEXT,
     UNIQUE (name, organization_id)
-);
-
-CREATE TABLE program_area (
-    id BIGSERIAL PRIMARY KEY,
-    name TEXT NOT NULL
-);
-
-CREATE TABLE county (
-    id BIGSERIAL PRIMARY KEY,
-    name TEXT NOT NULL,
-    state TEXT NOT NULL,
-    outer_boundary1 TEXT NOT NULL,
-    inner_boundary1 TEXT,
-    outer_boundary2 TEXT,
-    outer_boundary3 TEXT,
-    UNIQUE (name, state)
 );
 
 CREATE TABLE program_county (

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -46,6 +46,9 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-router/1.0.0-beta.2/angular-ui-router.js">
         </script>
 
+        <!--<script src="https://cdnjs.cloudflare.com/ajax/libs/satellizer/0.14.1/satellizer.min.js"></script>-->
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/satellizer/0.14.1/satellizer.js"></script>
+
         <!-- TODO: API KEY? -->
         <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyA_WiLcsn_2Z26Jo8eZwPOxl74zSkjhSFQ"></script>
 

--- a/src/test/java/org/hmhb/authentication/AuthenticationControllerTest.java
+++ b/src/test/java/org/hmhb/authentication/AuthenticationControllerTest.java
@@ -1,0 +1,41 @@
+package org.hmhb.authentication;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link AuthenticationController}.
+ */
+public class AuthenticationControllerTest {
+
+    private AuthenticationService service;
+
+    private AuthenticationController toTest;
+
+    @Before
+    public void setUp() throws Exception {
+        service = mock(AuthenticationService.class);
+        toTest = new AuthenticationController(service);
+    }
+
+    @Test
+    public void testCreate() throws Exception {
+        GoogleOauthAccessRequestInfo input = new GoogleOauthAccessRequestInfo();
+        input.setClientId("test-clientId");
+
+        TokenResponse expected = new TokenResponse("test-token");
+
+        /* Train the mocks. */
+        when(service.authenticate(input)).thenReturn(expected);
+
+        /* Make the call. */
+        TokenResponse actual = toTest.create(input);
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+}

--- a/src/test/java/org/hmhb/authentication/AuthenticationFilterTest.java
+++ b/src/test/java/org/hmhb/authentication/AuthenticationFilterTest.java
@@ -1,0 +1,56 @@
+package org.hmhb.authentication;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link AuthenticationFilter}.
+ */
+public class AuthenticationFilterTest {
+
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private FilterChain chain;
+    private JwtAuthenticationService service;
+
+    private AuthenticationFilter toTest;
+
+    @Before
+    public void setUp() throws Exception {
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        chain = mock(FilterChain.class);
+        service = mock(JwtAuthenticationService.class);
+        toTest = new AuthenticationFilter(service);
+    }
+
+    @Test
+    public void testDoFilter() throws Exception {
+        /* Make the call. */
+        toTest.doFilter(request, response, chain);
+
+        /* Verify the results. */
+        verify(service).validateAuthentication(request);
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    public void testDoFilterAuthFailure() throws Exception {
+        /* Train the mocks. */
+        doThrow(new RuntimeException("test-auth-failure")).when(service).validateAuthentication(request);
+
+        /* Make the call. */
+        toTest.doFilter(request, response, chain);
+
+        /* Verify the results. */
+        verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        verify(chain, never()).doFilter(request, response);
+    }
+
+}

--- a/src/test/java/org/hmhb/authentication/DefaultAuthenticationServiceTest.java
+++ b/src/test/java/org/hmhb/authentication/DefaultAuthenticationServiceTest.java
@@ -1,0 +1,161 @@
+package org.hmhb.authentication;
+
+import java.io.IOException;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
+import org.hmhb.exception.authentication.ClientIdMismatchException;
+import org.hmhb.exception.oauth.GoogleOauthException;
+import org.hmhb.exception.user.UserNotFoundException;
+import org.hmhb.oauth.GoogleOauthService;
+import org.hmhb.user.HmhbUser;
+import org.hmhb.user.UserService;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.env.Environment;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link DefaultAuthenticationService}.
+ */
+public class DefaultAuthenticationServiceTest {
+
+    private static final Long USER_ID = 123L;
+    private static final String USER_EMAIL = "test-email";
+    private static final String CODE = "test-code";
+    private static final String CLIENT_ID = "test-client-id";
+    private static final String CLIENT_SECRET = "test-client-secret";
+    private static final String PREFIX = "test-prefix/views/oauth-callback";
+    private static final String TOKEN = "test-token";
+
+    private Environment environment;
+    private GoogleOauthService googleOauthService;
+    private JwtAuthenticationService jwtAuthService;
+    private UserService userService;
+
+    private DefaultAuthenticationService toTest;
+
+    @Before
+    public void setUp() throws Exception {
+        environment = mock(Environment.class);
+        googleOauthService = mock(GoogleOauthService.class);
+        jwtAuthService = mock(JwtAuthenticationService.class);
+        userService = mock(UserService.class);
+        toTest = new DefaultAuthenticationService(
+                environment,
+                googleOauthService,
+                jwtAuthService,
+                userService
+        );
+    }
+
+    private GoogleOauthAccessRequestInfo prepGoogleCall() throws Exception {
+        GoogleTokenResponse googleTokenResponse = mock(GoogleTokenResponse.class);
+        GoogleIdToken googleIdToken = mock(GoogleIdToken.class);
+        GoogleIdToken.Payload payload = mock(GoogleIdToken.Payload.class);
+
+        /* Train the mocks. */
+        when(environment.getProperty("google.oauth.client.id")).thenReturn(CLIENT_ID);
+        when(environment.getProperty("google.oauth.client.secret")).thenReturn(CLIENT_SECRET);
+        when(
+                googleOauthService.getTokenResponse(
+                        CLIENT_ID,
+                        CLIENT_SECRET,
+                        CODE,
+                        PREFIX
+                )
+        ).thenReturn(
+                googleTokenResponse
+        );
+        when(googleTokenResponse.parseIdToken()).thenReturn(googleIdToken);
+        when(googleIdToken.getPayload()).thenReturn(payload);
+        when(payload.getEmail()).thenReturn(USER_EMAIL);
+
+        GoogleOauthAccessRequestInfo input = new GoogleOauthAccessRequestInfo();
+        input.setClientId(CLIENT_ID);
+        input.setCode(CODE);
+        input.setRedirectUri(PREFIX);
+        return input;
+    }
+
+    @Test(expected = ClientIdMismatchException.class)
+    public void testAuthenticateClientIdMismatch() throws Exception {
+        GoogleOauthAccessRequestInfo input = prepGoogleCall();
+        input.setClientId(CLIENT_ID + "-different");
+
+        /* Make the call. */
+        toTest.authenticate(input);
+
+    }
+
+    @Test(expected = GoogleOauthException.class)
+    public void testAuthenticateTokenParseException() throws Exception {
+        GoogleOauthAccessRequestInfo input = prepGoogleCall();
+
+        GoogleTokenResponse googleTokenResponse = mock(GoogleTokenResponse.class);
+
+        /* Train the mocks. */
+        when(
+                googleOauthService.getTokenResponse(
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyString()
+                )
+        ).thenReturn(
+                googleTokenResponse
+        );
+        when(googleTokenResponse.parseIdToken()).thenThrow(new IOException("test-io-exception"));
+
+        /* Make the call. */
+        toTest.authenticate(input);
+    }
+
+    @Test
+    public void testAuthenticate() throws Exception {
+        GoogleOauthAccessRequestInfo input = prepGoogleCall();
+
+        TokenResponse expected = new TokenResponse(TOKEN);
+
+        HmhbUser user = new HmhbUser();
+        user.setId(USER_ID);
+        user.setEmail(USER_EMAIL);
+        user.setAdmin(true);
+
+        /* Finish training the mocks. */
+        when(userService.getUserByEmail(USER_EMAIL)).thenReturn(user);
+        when(jwtAuthService.generateJwtToken(user)).thenReturn(TOKEN);
+
+        /* Make the call. */
+        TokenResponse actual = toTest.authenticate(input);
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testAuthenticateNewUser() throws Exception {
+        GoogleOauthAccessRequestInfo input = prepGoogleCall();
+
+        TokenResponse expected = new TokenResponse(TOKEN);
+
+        HmhbUser user = new HmhbUser();
+        user.setId(USER_ID);
+        user.setEmail(USER_EMAIL);
+        user.setAdmin(true);
+
+        /* Finish training the mocks. */
+        when(userService.getUserByEmail(USER_EMAIL)).thenThrow(new UserNotFoundException(USER_EMAIL));
+        when(userService.provisionNewUser(USER_EMAIL)).thenReturn(user);
+        when(jwtAuthService.generateJwtToken(user)).thenReturn(TOKEN);
+
+        /* Make the call. */
+        TokenResponse actual = toTest.authenticate(input);
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+}

--- a/src/test/java/org/hmhb/authentication/DefaultJwtAuthenticationServiceTest.java
+++ b/src/test/java/org/hmhb/authentication/DefaultJwtAuthenticationServiceTest.java
@@ -1,0 +1,153 @@
+package org.hmhb.authentication;
+
+import javax.servlet.http.HttpServletRequest;
+
+import io.jsonwebtoken.SignatureException;
+import org.hmhb.exception.authentication.AuthHeaderHasTooManyPartsException;
+import org.hmhb.exception.authentication.AuthHeaderMissingTokenException;
+import org.hmhb.exception.authentication.AuthHeaderUnknownException;
+import org.hmhb.user.HmhbUser;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.env.Environment;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link DefaultJwtAuthenticationService}.
+ */
+public class DefaultJwtAuthenticationServiceTest {
+
+    private static final String TEST_DOMAIN = "test-domain";
+    private static final String TEST_SECRET = "test-secret";
+    private static final Long USER_ID = 123L;
+    private static final String USER_EMAIL = "john.doe@mailinator.com";
+
+    private HttpServletRequest request;
+    private Environment environment;
+
+    private DefaultJwtAuthenticationService toTest;
+
+    @Before
+    public void setUp() throws Exception {
+        environment = mock(Environment.class);
+        request = mock(HttpServletRequest.class);
+        toTest = new DefaultJwtAuthenticationService(environment);
+    }
+
+    @Test
+    public void testJwtToken() throws Exception {
+        HmhbUser user = new HmhbUser();
+        user.setId(USER_ID);
+        user.setEmail(USER_EMAIL);
+        user.setAdmin(false);
+
+        /* Train the config. */
+        when(environment.getProperty("hmhb.jwt.domain")).thenReturn(TEST_DOMAIN);
+        when(environment.getProperty("hmhb.jwt.secret")).thenReturn(TEST_SECRET);
+
+        /* Make the generate call. */
+        String token = toTest.generateJwtToken(user);
+
+        /* Train the mocks. */
+        when(environment.getProperty("hmhb.jwt.domain")).thenReturn(TEST_DOMAIN);
+        when(environment.getProperty("hmhb.jwt.secret")).thenReturn(TEST_SECRET);
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+
+        /* Make the validate call. */
+        toTest.validateAuthentication(request);
+
+        /* Verify the results. */
+        verify(request).setAttribute("loggedInUser", user);
+    }
+
+    @Test(expected = SignatureException.class)
+    public void testJwtToken_Tampered() throws Exception {
+        HmhbUser user = new HmhbUser();
+        user.setId(USER_ID);
+        user.setEmail(USER_EMAIL);
+        user.setAdmin(false);
+
+        /* Train the config. */
+        when(environment.getProperty("hmhb.jwt.domain")).thenReturn(TEST_DOMAIN);
+        when(environment.getProperty("hmhb.jwt.secret")).thenReturn(TEST_SECRET);
+
+        /* Make the generate call. */
+        String token = toTest.generateJwtToken(user);
+
+        /* Train the mocks. */
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token + "tampered");
+
+        /* Make the validate call. */
+        toTest.validateAuthentication(request);
+    }
+
+    @Test
+    public void testJwtToken_NoAuthHeader() throws Exception {
+        /* Train the mocks. */
+        when(request.getHeader("Authorization")).thenReturn(null);
+
+        /* Make the validate call. */
+        toTest.validateAuthentication(request);
+
+        /* Verify nothing was done. */
+        verify(request, never()).setAttribute(anyString(), anyObject());
+    }
+
+    @Test(expected = AuthHeaderMissingTokenException.class)
+    public void testJwtToken_AuthHeaderNotEnoughParts() throws Exception {
+        HmhbUser user = new HmhbUser();
+        user.setId(USER_ID);
+        user.setEmail(USER_EMAIL);
+        user.setAdmin(false);
+
+        /* Train the mocks. */
+        when(request.getHeader("Authorization")).thenReturn("Bearer");
+
+        /* Make the validate call. */
+        toTest.validateAuthentication(request);
+    }
+
+    @Test(expected = AuthHeaderHasTooManyPartsException.class)
+    public void testJwtToken_AuthHeaderTooManyParts() throws Exception {
+        HmhbUser user = new HmhbUser();
+        user.setId(USER_ID);
+        user.setEmail(USER_EMAIL);
+        user.setAdmin(false);
+
+        /* Train the config. */
+        when(environment.getProperty("hmhb.jwt.domain")).thenReturn(TEST_DOMAIN);
+        when(environment.getProperty("hmhb.jwt.secret")).thenReturn(TEST_SECRET);
+
+        /* Make the generate call. */
+        String token = toTest.generateJwtToken(user);
+
+        /* Train the mocks. */
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token + " " + token);
+
+        /* Make the validate call. */
+        toTest.validateAuthentication(request);
+    }
+
+    @Test(expected = AuthHeaderUnknownException.class)
+    public void testJwtToken_UnknownAuthHeader() throws Exception {
+        HmhbUser user = new HmhbUser();
+        user.setId(USER_ID);
+        user.setEmail(USER_EMAIL);
+        user.setAdmin(false);
+
+        /* Train the config. */
+        when(environment.getProperty("hmhb.jwt.domain")).thenReturn(TEST_DOMAIN);
+        when(environment.getProperty("hmhb.jwt.secret")).thenReturn(TEST_SECRET);
+
+        /* Make the generate call. */
+        String token = toTest.generateJwtToken(user);
+
+        /* Train the mocks. */
+        when(request.getHeader("Authorization")).thenReturn("test-unknown-auth-header " + token);
+
+        /* Make the validate call. */
+        toTest.validateAuthentication(request);
+    }
+
+}

--- a/src/test/java/org/hmhb/authorization/DefaultAuthorizationServiceTest.java
+++ b/src/test/java/org/hmhb/authorization/DefaultAuthorizationServiceTest.java
@@ -1,0 +1,95 @@
+package org.hmhb.authorization;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.hmhb.user.HmhbUser;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link DefaultAuthorizationService}.
+ */
+public class DefaultAuthorizationServiceTest {
+
+    private HttpServletRequest request;
+
+    private DefaultAuthorizationService toTest;
+
+    @Before
+    public void setUp() throws Exception {
+        request = mock(HttpServletRequest.class);
+        toTest = new DefaultAuthorizationService(request);
+    }
+
+    @Test
+    public void testIsLoggedIn_NotLoggedIn() throws Exception {
+        /* Train the mocks. */
+        when(request.getAttribute("loggedInUser")).thenReturn(null);
+
+        /* Make the call. */
+        boolean actual = toTest.isLoggedIn();
+
+        /* Verify the results. */
+        assertFalse(actual);
+    }
+
+    @Test
+    public void testIsLoggedIn_LoggedIn() throws Exception {
+        HmhbUser user = new HmhbUser();
+
+        /* Train the mocks. */
+        when(request.getAttribute("loggedInUser")).thenReturn(user);
+
+        /* Make the call. */
+        boolean actual = toTest.isLoggedIn();
+
+        /* Verify the results. */
+        assertTrue(actual);
+    }
+
+    @Test
+    public void testIsAdmin_NotLoggedIn() throws Exception {
+        /* Train the mocks. */
+        when(request.getAttribute("loggedInUser")).thenReturn(null);
+
+        /* Make the call. */
+        boolean actual = toTest.isAdmin();
+
+        /* Verify the results. */
+        assertFalse(actual);
+    }
+
+    @Test
+    public void testIsAdmin_PartnerLoggedIn() throws Exception {
+        HmhbUser user = new HmhbUser();
+        user.setAdmin(false);
+
+        /* Train the mocks. */
+        when(request.getAttribute("loggedInUser")).thenReturn(user);
+
+        /* Make the call. */
+        boolean actual = toTest.isAdmin();
+
+        /* Verify the results. */
+        assertFalse(actual);
+    }
+
+    @Test
+    public void testIsAdmin_AdminLoggedIn() throws Exception {
+        HmhbUser user = new HmhbUser();
+        user.setAdmin(true);
+
+        /* Train the mocks. */
+        when(request.getAttribute("loggedInUser")).thenReturn(user);
+
+        /* Make the call. */
+        boolean actual = toTest.isAdmin();
+
+        /* Verify the results. */
+        assertTrue(actual);
+    }
+
+}

--- a/src/test/java/org/hmhb/program/DefaultProgramServiceTest.java
+++ b/src/test/java/org/hmhb/program/DefaultProgramServiceTest.java
@@ -5,7 +5,10 @@ import java.util.Date;
 import java.util.List;
 
 import org.hmhb.audit.AuditHelper;
+import org.hmhb.authorization.AuthorizationService;
 import org.hmhb.county.County;
+import org.hmhb.exception.program.OnlyAdminCanDeleteProgramException;
+import org.hmhb.exception.program.OnlyAdminCanSaveProgramException;
 import org.hmhb.exception.program.ProgramMeasurableOutcome1RequiredException;
 import org.hmhb.exception.program.ProgramNameRequiredException;
 import org.hmhb.exception.program.ProgramNotFoundException;
@@ -53,6 +56,7 @@ public class DefaultProgramServiceTest {
     private static final String GEO_CODE = "-1.00000000,1.00000000";
 
     private AuditHelper auditHelper;
+    private AuthorizationService authorizationService;
     private GeocodeService geocodeService;
     private OrganizationService organizationService;
     private ProgramDao dao;
@@ -61,11 +65,18 @@ public class DefaultProgramServiceTest {
     @Before
     public void setUp() throws Exception {
         auditHelper = mock(AuditHelper.class);
+        authorizationService = mock(AuthorizationService.class);
         geocodeService = mock(GeocodeService.class);
         organizationService = mock(OrganizationService.class);
         dao = mock(ProgramDao.class);
 
-        toTest = new DefaultProgramService(auditHelper, geocodeService, organizationService, dao);
+        toTest = new DefaultProgramService(
+                auditHelper,
+                authorizationService,
+                geocodeService,
+                organizationService,
+                dao
+        );
     }
 
     private LocationInfo createLocationInfo() {
@@ -190,6 +201,7 @@ public class DefaultProgramServiceTest {
         Program programInDb = createFilledInProgram();
 
         /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
         when(dao.findOne(PROGRAM_ID)).thenReturn(programInDb);
 
         /* Make the call. */
@@ -203,7 +215,17 @@ public class DefaultProgramServiceTest {
     @Test(expected = ProgramNotFoundException.class)
     public void testDeleteNotFound() throws Exception {
         /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
         when(dao.findOne(PROGRAM_ID)).thenReturn(null);
+
+        /* Make the call. */
+        toTest.delete(PROGRAM_ID);
+    }
+
+    @Test(expected = OnlyAdminCanDeleteProgramException.class)
+    public void testDeleteNotAdmin() throws Exception {
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(false);
 
         /* Make the call. */
         toTest.delete(PROGRAM_ID);
@@ -215,6 +237,9 @@ public class DefaultProgramServiceTest {
         input.setId(null);
         input.setName(null);
 
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+
         /* Make the call. */
         toTest.save(input);
     }
@@ -224,6 +249,9 @@ public class DefaultProgramServiceTest {
         Program input = createFilledInProgram();
         input.setId(null);
         input.setName("");
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
 
         /* Make the call. */
         toTest.save(input);
@@ -235,6 +263,9 @@ public class DefaultProgramServiceTest {
         input.setId(null);
         input.setName(" ");
 
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+
         /* Make the call. */
         toTest.save(input);
     }
@@ -244,6 +275,9 @@ public class DefaultProgramServiceTest {
         Program input = createFilledInProgram();
         input.setId(null);
         input.setPrimaryGoal1(null);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
 
         /* Make the call. */
         toTest.save(input);
@@ -255,6 +289,9 @@ public class DefaultProgramServiceTest {
         input.setId(null);
         input.setPrimaryGoal1("");
 
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+
         /* Make the call. */
         toTest.save(input);
     }
@@ -264,6 +301,9 @@ public class DefaultProgramServiceTest {
         Program input = createFilledInProgram();
         input.setId(null);
         input.setPrimaryGoal1(" ");
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
 
         /* Make the call. */
         toTest.save(input);
@@ -275,6 +315,9 @@ public class DefaultProgramServiceTest {
         input.setId(null);
         input.setMeasurableOutcome1(null);
 
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+
         /* Make the call. */
         toTest.save(input);
     }
@@ -284,6 +327,9 @@ public class DefaultProgramServiceTest {
         Program input = createFilledInProgram();
         input.setId(null);
         input.setMeasurableOutcome1("");
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
 
         /* Make the call. */
         toTest.save(input);
@@ -295,6 +341,9 @@ public class DefaultProgramServiceTest {
         input.setId(null);
         input.setMeasurableOutcome1(" ");
 
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+
         /* Make the call. */
         toTest.save(input);
     }
@@ -304,6 +353,9 @@ public class DefaultProgramServiceTest {
         Program input = createFilledInProgram();
         input.setId(null);
         input.setOrganization(null);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
 
         /* Make the call. */
         toTest.save(input);
@@ -315,6 +367,9 @@ public class DefaultProgramServiceTest {
         input.setId(null);
         input.setState(null);
 
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+
         /* Make the call. */
         toTest.save(input);
     }
@@ -325,6 +380,9 @@ public class DefaultProgramServiceTest {
         input.setId(null);
         input.setState("");
 
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+
         /* Make the call. */
         toTest.save(input);
     }
@@ -334,6 +392,9 @@ public class DefaultProgramServiceTest {
         Program input = createFilledInProgram();
         input.setId(null);
         input.setState(" ");
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
 
         /* Make the call. */
         toTest.save(input);
@@ -346,6 +407,7 @@ public class DefaultProgramServiceTest {
         input.setZipCode(null);
 
         /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
         when(organizationService.getById(ORG_ID)).thenReturn(createOrg());
         when(auditHelper.getCurrentUser()).thenReturn(USERNAME_1);
         when(auditHelper.getCurrentTime()).thenReturn(CREATED_ON);
@@ -367,6 +429,7 @@ public class DefaultProgramServiceTest {
         locationInfo.setZipCode(null);
 
         /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
         when(organizationService.getById(ORG_ID)).thenReturn(createOrg());
         when(auditHelper.getCurrentUser()).thenReturn(USERNAME_1);
         when(auditHelper.getCurrentTime()).thenReturn(CREATED_ON);
@@ -383,6 +446,7 @@ public class DefaultProgramServiceTest {
         input.setZipCode("");
 
         /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
         when(organizationService.getById(ORG_ID)).thenReturn(createOrg());
         when(auditHelper.getCurrentUser()).thenReturn(USERNAME_1);
         when(auditHelper.getCurrentTime()).thenReturn(CREATED_ON);
@@ -404,6 +468,7 @@ public class DefaultProgramServiceTest {
         locationInfo.setZipCode(null);
 
         /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
         when(organizationService.getById(ORG_ID)).thenReturn(createOrg());
         when(auditHelper.getCurrentUser()).thenReturn(USERNAME_1);
         when(auditHelper.getCurrentTime()).thenReturn(CREATED_ON);
@@ -420,6 +485,7 @@ public class DefaultProgramServiceTest {
         input.setZipCode(" ");
 
         /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
         when(organizationService.getById(ORG_ID)).thenReturn(createOrg());
         when(auditHelper.getCurrentUser()).thenReturn(USERNAME_1);
         when(auditHelper.getCurrentTime()).thenReturn(CREATED_ON);
@@ -441,6 +507,7 @@ public class DefaultProgramServiceTest {
         locationInfo.setZipCode(null);
 
         /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
         when(organizationService.getById(ORG_ID)).thenReturn(createOrg());
         when(auditHelper.getCurrentUser()).thenReturn(USERNAME_1);
         when(auditHelper.getCurrentTime()).thenReturn(CREATED_ON);
@@ -457,6 +524,7 @@ public class DefaultProgramServiceTest {
         input.setStartYear(null);
 
         /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
         when(organizationService.getById(ORG_ID)).thenReturn(createOrg());
         when(auditHelper.getCurrentUser()).thenReturn(USERNAME_1);
         when(auditHelper.getCurrentTime()).thenReturn(CREATED_ON);
@@ -496,6 +564,7 @@ public class DefaultProgramServiceTest {
         inputWithCreatedAuditFilledIn.setCoordinates(GEO_CODE);
 
         /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
         when(organizationService.getById(ORG_ID)).thenReturn(createOrg());
         when(auditHelper.getCurrentUser()).thenReturn(USERNAME_1);
         when(auditHelper.getCurrentTime()).thenReturn(CREATED_ON);
@@ -507,6 +576,19 @@ public class DefaultProgramServiceTest {
 
         /* Verify the results. */
         assertEquals(inputWithCreatedAuditFilledIn, actual);
+    }
+
+    @Test(expected = OnlyAdminCanSaveProgramException.class)
+    public void testSaveCreateNewNotAdmin() throws Exception {
+        Program input = createFilledInProgram();
+        input.setId(null);
+        input.setName(PROGRAM_NAME);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(false);
+
+        /* Make the call. */
+        toTest.save(input);
     }
 
     @Test
@@ -537,6 +619,7 @@ public class DefaultProgramServiceTest {
         inputWithCreatedAuditFilledIn.setCoordinates(GEO_CODE);
 
         /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
         when(organizationService.save(inputOrg)).thenReturn(createOrg());
         when(auditHelper.getCurrentUser()).thenReturn(USERNAME_1);
         when(auditHelper.getCurrentTime()).thenReturn(CREATED_ON);
@@ -587,6 +670,7 @@ public class DefaultProgramServiceTest {
         inputWithUpdatedAuditFilledIn.setCoordinates(GEO_CODE);
 
         /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
         when(organizationService.getById(ORG_ID)).thenReturn(createOrg());
         when(dao.findOne(PROGRAM_ID)).thenReturn(oldProgramInDb);
         when(auditHelper.getCurrentUser()).thenReturn(USERNAME_2);
@@ -638,6 +722,7 @@ public class DefaultProgramServiceTest {
         inputWithUpdatedAuditFilledIn.setCoordinates(GEO_CODE);
 
         /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
         when(organizationService.save(inputOrg)).thenReturn(createOrg());
         when(dao.findOne(PROGRAM_ID)).thenReturn(oldProgramInDb);
         when(auditHelper.getCurrentUser()).thenReturn(USERNAME_2);
@@ -659,8 +744,22 @@ public class DefaultProgramServiceTest {
         input.setName(ORG_NAME);
 
         /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
         when(geocodeService.getLocationInfo(notNull(Program.class))).thenReturn(createLocationInfo());
         when(dao.findOne(PROGRAM_ID)).thenReturn(null);
+
+        /* Make the call. */
+        toTest.save(input);
+    }
+
+    @Test(expected = OnlyAdminCanSaveProgramException.class)
+    public void testSaveUpdateExistingProgramNotAdmin() throws Exception {
+        Program input = createFilledInProgram();
+        input.setId(PROGRAM_ID);
+        input.setName(ORG_NAME);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(false);
 
         /* Make the call. */
         toTest.save(input);


### PR DESCRIPTION
* Adds auth modules, configs, components, etc. to support google oauth.
* Adds user table and code to support partners and admins.
* Adds admin requirement to all CRUD operations on programs.
* Adds admin requirement to delete and updating of organizations.
* Updates README with info about new required config.
* Updates the unit tests.