### PR TITLE
closes #234: Downgrade to java7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ allprojects {
     apply plugin: 'idea'
     apply plugin: 'eclipse'
 
-    sourceCompatibility = 1.8
-    targetCompatibility = 1.8
+    sourceCompatibility = 1.7
+    targetCompatibility = 1.7
 
     group = 'org.hmhb'
     version = '1.0-SNAPSHOT'

--- a/src/main/java/org/hmhb/mapquery/DefaultMapQueryService.java
+++ b/src/main/java/org/hmhb/mapquery/DefaultMapQueryService.java
@@ -3,7 +3,6 @@ package org.hmhb.mapquery;
 import javax.annotation.Nonnull;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.codahale.metrics.annotation.Timed;
 import org.hmhb.county.County;
@@ -58,10 +57,18 @@ public class DefaultMapQueryService implements MapQueryService {
             countyId = county.getId().toString();
         }
 
-        String commaSeparatedProgramIds = programs.stream()
-                .map(Program::getId)
-                .map(Object::toString)
-                .collect(Collectors.joining(","));
+        StringBuilder programIdsBuilder = new StringBuilder();
+
+        for (Program program : programs) {
+            programIdsBuilder.append(program.getId());
+            programIdsBuilder.append(',');
+        }
+
+        String commaSeparatedProgramIds = programIdsBuilder.toString();
+
+        if (!commaSeparatedProgramIds.isEmpty()) {
+            commaSeparatedProgramIds = commaSeparatedProgramIds.substring(0, commaSeparatedProgramIds.length() - 1);
+        }
 
         MapQueryResult result = new MapQueryResult();
         result.setPrograms(programs);

--- a/src/test/java/org/hmhb/kml/DefaultKmlServiceTest.java
+++ b/src/test/java/org/hmhb/kml/DefaultKmlServiceTest.java
@@ -89,7 +89,7 @@ public class DefaultKmlServiceTest {
          * Due to the results being an xml string, I'm using Mockito's verify
          * (instead of trying to interpret or parse the xml string).
          */
-        verify(programService, never()).getByIds(any());
+        verify(programService, never()).getByIds(anyListOf(Long.class));
         verify(countyService).getAll();
     }
 

--- a/src/test/java/org/hmhb/organization/DefaultOrganizationServiceTest.java
+++ b/src/test/java/org/hmhb/organization/DefaultOrganizationServiceTest.java
@@ -113,7 +113,7 @@ public class DefaultOrganizationServiceTest {
         /* Train the mocks. */
         when(authorizationService.isAdmin()).thenReturn(true);
         when(dao.findOne(ORG_ID)).thenReturn(orgInDb);
-        when(programDao.findByOrganizationId(ORG_ID)).thenReturn(Collections.emptyList());
+        when(programDao.findByOrganizationId(ORG_ID)).thenReturn(Collections.<Program>emptyList());
 
         /* Make the call. */
         Organization actual = toTest.delete(ORG_ID);


### PR DESCRIPTION
* Changes source & target compatibility from 1.8 to 1.7.
* Removes last usage of stream, lambda, and Collectors.
* Fixes unit tests that needed more specific generics in 1.7.