### PR TITLE
closes #239: Add google+ profile info to JWT token

### DIFF
--- a/client/src/main/webjar/authentication/authentication.config.js
+++ b/client/src/main/webjar/authentication/authentication.config.js
@@ -45,6 +45,10 @@
                 optionalUrlParams: [
                     "prompt"
                 ],
+                scope: [
+                    "profile",
+                    "email"
+                ],
                 url: "/auth/google", /* posts to our server */
                 redirectUri: redirectUri, /* redirects to the angular app; this has to match what the server uses */
                 /* TODO: get the clientId and redirectUrl from the server */

--- a/src/main/java/org/hmhb/authentication/DefaultJwtAuthenticationService.java
+++ b/src/main/java/org/hmhb/authentication/DefaultJwtAuthenticationService.java
@@ -70,6 +70,14 @@ public class DefaultJwtAuthenticationService implements JwtAuthenticationService
         claims.put("admin", user.isAdmin());
         claims.put("email", user.getEmail());
         claims.put("userId", user.getId());
+        claims.put("displayName", user.getDisplayName());
+        claims.put("imageUrl", user.getImageUrl());
+        claims.put("profileUrl", user.getProfileUrl());
+        claims.put("firstName", user.getFirstName());
+        claims.put("lastName", user.getLastName());
+        claims.put("middleName", user.getMiddleName());
+        claims.put("prefix", user.getPrefix());
+        claims.put("suffix", user.getSuffix());
 
         String domainId = getDomain();
         String secret = getSecret();
@@ -147,6 +155,14 @@ public class DefaultJwtAuthenticationService implements JwtAuthenticationService
             boolean admin = claims.get("admin", Boolean.class);
             String email = claims.get("email", String.class);
             Long userId = claims.get("userId", Integer.class).longValue();
+            String displayName = claims.get("displayName", String.class);
+            String imageUrl = claims.get("imageUrl", String.class);
+            String profileUrl = claims.get("profileUrl", String.class);
+            String firstName = claims.get("firstName", String.class);
+            String lastName = claims.get("lastName", String.class);
+            String middleName = claims.get("middleName", String.class);
+            String prefix = claims.get("prefix", String.class);
+            String suffix = claims.get("suffix", String.class);
 
             Date now = new Date();
 
@@ -178,6 +194,14 @@ public class DefaultJwtAuthenticationService implements JwtAuthenticationService
             user.setAdmin(admin);
             user.setEmail(email);
             user.setId(userId);
+            user.setDisplayName(displayName);
+            user.setImageUrl(imageUrl);
+            user.setProfileUrl(profileUrl);
+            user.setFirstName(firstName);
+            user.setLastName(lastName);
+            user.setMiddleName(middleName);
+            user.setPrefix(prefix);
+            user.setSuffix(suffix);
 
             request.setAttribute("loggedInUser", user);
         }

--- a/src/main/java/org/hmhb/oauth/DefaultGoogleOauthService.java
+++ b/src/main/java/org/hmhb/oauth/DefaultGoogleOauthService.java
@@ -3,11 +3,17 @@ package org.hmhb.oauth;
 import javax.annotation.Nonnull;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeTokenRequest;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.plus.Plus;
+import com.google.api.services.plus.model.Person;
 import org.hmhb.exception.oauth.GoogleOauthException;
 import org.springframework.stereotype.Service;
 
@@ -18,7 +24,7 @@ import org.springframework.stereotype.Service;
 public class DefaultGoogleOauthService implements GoogleOauthService {
 
     @Override
-    public GoogleTokenResponse getTokenResponse(
+    public GoogleResponseData getUserDataFromGoogle(
             @Nonnull String clientId,
             @Nonnull String clientSecret,
             @Nonnull String code,
@@ -27,7 +33,7 @@ public class DefaultGoogleOauthService implements GoogleOauthService {
 
         try {
 
-            return new GoogleAuthorizationCodeTokenRequest(
+            GoogleTokenResponse oauthResponse = new GoogleAuthorizationCodeTokenRequest(
                     new NetHttpTransport(),
                     new JacksonFactory(),
                     clientId,
@@ -35,6 +41,33 @@ public class DefaultGoogleOauthService implements GoogleOauthService {
                     code,
                     redirectUri
             ).execute();
+
+            GoogleCredential credential = new GoogleCredential()
+                    .setAccessToken(
+                            oauthResponse.getAccessToken()
+                    );
+
+            Plus plus = new Plus.Builder(
+                    new NetHttpTransport(),
+                    new JacksonFactory(),
+                    new HttpRequestInitializer() {
+                        @Override
+                        public void initialize(HttpRequest request) throws IOException {
+                            // empty
+                        }
+                    }
+            ).setHttpRequestInitializer(
+                    credential
+            ).build();
+
+            Person gPlusResponse = plus.people()
+                    .get("me")
+                    .execute();
+
+            return new GoogleResponseData(
+                    oauthResponse,
+                    gPlusResponse
+            );
 
         } catch (IOException e) {
             throw new GoogleOauthException("Failed to call into google for token!", e);

--- a/src/main/java/org/hmhb/oauth/GoogleOauthService.java
+++ b/src/main/java/org/hmhb/oauth/GoogleOauthService.java
@@ -16,9 +16,10 @@ public interface GoogleOauthService {
      * @param clientSecret the oauth client secret
      * @param code the code from the user's request token
      * @param redirectUri the redirect uri for the request
-     * @return google's token response, which includes an email
+     * @return google's g+ profile and oauth token response, which includes an
+     * email
      */
-    GoogleTokenResponse getTokenResponse(
+    GoogleResponseData getUserDataFromGoogle(
             @Nonnull String clientId,
             @Nonnull String clientSecret,
             @Nonnull String code,

--- a/src/main/java/org/hmhb/oauth/GoogleResponseData.java
+++ b/src/main/java/org/hmhb/oauth/GoogleResponseData.java
@@ -1,0 +1,60 @@
+package org.hmhb.oauth;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
+import com.google.api.services.plus.model.Person;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * An object to hold the user's information from google's responses.
+ */
+@Immutable
+public class GoogleResponseData {
+
+    private final GoogleTokenResponse googleOauthToken;
+    private final Person googlePlusProfile;
+
+    /**
+     * Constructs a {@link GoogleResponseData}.
+     *
+     * @param googleOauthToken google's oauth token response
+     * @param googlePlusProfile google's g+ profile response
+     */
+    public GoogleResponseData(
+            @Nonnull GoogleTokenResponse googleOauthToken,
+            @Nonnull Person googlePlusProfile
+    ) {
+        this.googleOauthToken = requireNonNull(googleOauthToken, "googleOauthToken cannot be null");
+        this.googlePlusProfile = requireNonNull(googlePlusProfile, "googlePlusProfile cannot be null");
+    }
+
+    public GoogleTokenResponse getGoogleOauthToken() {
+        return googleOauthToken;
+    }
+
+    public Person getGooglePlusProfile() {
+        return googlePlusProfile;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/org/hmhb/user/HmhbUser.java
+++ b/src/main/java/org/hmhb/user/HmhbUser.java
@@ -24,7 +24,23 @@ public class HmhbUser {
     private String email;
 
     @NotNull
-    private boolean isAdmin;
+    private boolean admin;
+
+    private String displayName;
+
+    private String imageUrl;
+
+    private String lastName;
+
+    private String firstName;
+
+    private String middleName;
+
+    private String prefix;
+
+    private String suffix;
+
+    private String profileUrl;
 
     @Override
     public boolean equals(Object o) {
@@ -58,11 +74,75 @@ public class HmhbUser {
     }
 
     public boolean isAdmin() {
-        return isAdmin;
+        return admin;
     }
 
     public void setAdmin(boolean admin) {
-        isAdmin = admin;
+        this.admin = admin;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getMiddleName() {
+        return middleName;
+    }
+
+    public void setMiddleName(String middleName) {
+        this.middleName = middleName;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getSuffix() {
+        return suffix;
+    }
+
+    public void setSuffix(String suffix) {
+        this.suffix = suffix;
+    }
+
+    public String getProfileUrl() {
+        return profileUrl;
+    }
+
+    public void setProfileUrl(String profileUrl) {
+        this.profileUrl = profileUrl;
     }
 
 }

--- a/src/main/java/org/hmhb/user/UserService.java
+++ b/src/main/java/org/hmhb/user/UserService.java
@@ -2,29 +2,24 @@ package org.hmhb.user;
 
 import javax.annotation.Nonnull;
 
+import com.google.api.services.plus.model.Person;
+
 /**
  * Service to create and retrieve {@link HmhbUser}s.
  */
 public interface UserService {
 
     /**
-     * Retrieves a {@link HmhbUser} by its email.
+     * Updates an existing user, or creates a new non-admin {@link HmhbUser} in
+     * the system based on the data passed in from google.
      *
-     * @param email the email to look up a {@link HmhbUser} for
+     * @param email the email to lookup or save into the {@link HmhbUser}
+     * @param profile the user's google+ profile
      * @return the {@link HmhbUser}
      */
-    HmhbUser getUserByEmail(
-            @Nonnull String email
-    );
-
-    /**
-     * Creates a new non-admin {@link HmhbUser} in the system.
-     *
-     * @param email the email to save into the {@link HmhbUser}
-     * @return the newly created {@link HmhbUser}
-     */
-    HmhbUser provisionNewUser(
-            @Nonnull String email
+    HmhbUser saveWithGoogleData(
+            @Nonnull String email,
+            @Nonnull Person profile
     );
 
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -5,7 +5,7 @@
  **********************************/
 INSERT INTO hmhb_user (
     email,
-    is_admin
+    admin
 ) VALUES (
     'john.ryan.bard@gmail.com',
     TRUE
@@ -13,7 +13,7 @@ INSERT INTO hmhb_user (
 
 INSERT INTO hmhb_user (
     email,
-    is_admin
+    admin
 ) VALUES (
     'mckoon@gmail.com',
     TRUE
@@ -21,7 +21,7 @@ INSERT INTO hmhb_user (
 
 INSERT INTO hmhb_user (
     email,
-    is_admin
+    admin
 ) VALUES (
     'jlgett@gmail.com',
     TRUE

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -11,7 +11,15 @@ DROP TABLE IF EXISTS hmhb_user;
 CREATE TABLE hmhb_user (
     id BIGSERIAL PRIMARY KEY,
     email TEXT NOT NULL UNIQUE,
-    is_admin BOOLEAN NOT NULL
+    admin BOOLEAN NOT NULL,
+    display_name TEXT,
+    image_url TEXT,
+    first_name TEXT,
+    last_name TEXT,
+    middle_name TEXT,
+    prefix TEXT,
+    suffix TEXT,
+    profile_url TEXT
 );
 
 CREATE TABLE organization (

--- a/src/test/java/org/hmhb/user/DefaultUserServiceTest.java
+++ b/src/test/java/org/hmhb/user/DefaultUserServiceTest.java
@@ -1,6 +1,6 @@
 package org.hmhb.user;
 
-import org.hmhb.exception.user.UserNotFoundException;
+import com.google.api.services.plus.model.Person;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -12,7 +12,13 @@ import static org.mockito.Mockito.*;
  */
 public class DefaultUserServiceTest {
 
+    private static final Long USER_ID = 123L;
+    private static final String DISPLAY_NAME = "John Doe";
     private static final String EMAIL = "john.doe@mailinator.com";
+    private static final String FIRST_NAME = "John";
+    private static final String LAST_NAME = "Doe";
+    private static final String IMAGE_URL = "https://lh3.googleusercontent.com/-XdUIq/AAAI/AAAA/42cv5M/photo.jpg?sz=50";
+    private static final String PROFILE_URL = "something";
 
     private UserDao dao;
     private DefaultUserService toTest;
@@ -24,32 +30,84 @@ public class DefaultUserServiceTest {
     }
 
     @Test
-    public void testGetUserByEmail() throws Exception {
+    public void testSaveWithGoogleData() throws Exception {
+        HmhbUser userInDb = new HmhbUser();
+        userInDb.setId(USER_ID);
+        userInDb.setAdmin(true);
+        userInDb.setEmail(EMAIL);
+        userInDb.setDisplayName(DISPLAY_NAME + "-old");
+        userInDb.setFirstName(FIRST_NAME + "-old");
+        userInDb.setLastName(LAST_NAME + "-old");
+        userInDb.setImageUrl(IMAGE_URL + "-old");
+        userInDb.setProfileUrl(PROFILE_URL + "-old");
+
         HmhbUser expected = new HmhbUser();
+        expected.setId(USER_ID);
+        expected.setAdmin(true);
         expected.setEmail(EMAIL);
+        expected.setDisplayName(DISPLAY_NAME);
+        expected.setFirstName(FIRST_NAME);
+        expected.setLastName(LAST_NAME);
+        expected.setImageUrl(IMAGE_URL);
+        expected.setProfileUrl(PROFILE_URL);
+
+        Person.Image image = new Person.Image();
+        image.setUrl(IMAGE_URL);
+
+        Person.Name name = new Person.Name();
+        name.setFamilyName(LAST_NAME);
+        name.setGivenName(FIRST_NAME);
+
+        Person gPlusProfile = new Person();
+        gPlusProfile.setUrl(PROFILE_URL);
+        gPlusProfile.setDisplayName(DISPLAY_NAME);
+        gPlusProfile.setImage(image);
+        gPlusProfile.setName(name);
 
         /* Train the mocks. */
-        when(dao.findByEmailIgnoreCase(EMAIL)).thenReturn(expected);
+        when(dao.findByEmailIgnoreCase(EMAIL)).thenReturn(userInDb);
+        when(dao.save(expected)).thenReturn(expected);
 
         /* Make the call. */
-        HmhbUser actual = toTest.getUserByEmail(EMAIL);
+        HmhbUser actual = toTest.saveWithGoogleData(EMAIL, gPlusProfile);
 
         /* Verify the results. */
-        assertEquals(expected, actual);
-    }
-
-    @Test(expected = UserNotFoundException.class)
-    public void testGetUserByEmail_NotFound() throws Exception {
-        /* Train the mocks. */
-        when(dao.findByEmailIgnoreCase(EMAIL)).thenReturn(null);
-
-        /* Make the call. */
-        toTest.getUserByEmail(EMAIL);
+        assertEquals(userInDb, actual);
     }
 
     @Test
-    public void testProvisionNewUser() throws Exception {
+    public void testSaveWithGoogleData_NotFound() throws Exception {
+        HmhbUser expected = new HmhbUser();
+        expected.setAdmin(false);
+        expected.setEmail(EMAIL);
+        expected.setDisplayName(DISPLAY_NAME);
+        expected.setFirstName(FIRST_NAME);
+        expected.setLastName(LAST_NAME);
+        expected.setImageUrl(IMAGE_URL);
+        expected.setProfileUrl(PROFILE_URL);
 
+        Person.Image image = new Person.Image();
+        image.setUrl(IMAGE_URL);
+
+        Person.Name name = new Person.Name();
+        name.setFamilyName(LAST_NAME);
+        name.setGivenName(FIRST_NAME);
+
+        Person gPlusProfile = new Person();
+        gPlusProfile.setUrl(PROFILE_URL);
+        gPlusProfile.setDisplayName(DISPLAY_NAME);
+        gPlusProfile.setImage(image);
+        gPlusProfile.setName(name);
+
+        /* Train the mocks. */
+        when(dao.findByEmailIgnoreCase(EMAIL)).thenReturn(null);
+        when(dao.save(expected)).thenReturn(expected);
+
+        /* Make the call. */
+        HmhbUser actual = toTest.saveWithGoogleData(EMAIL, gPlusProfile);
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
     }
 
 }


### PR DESCRIPTION
* Adds call for google+ profile information to oauth service.
* Adds g+ profile information to JWT claims so it's available to the client.
* Adds g+ profile info to hmhb_user and HmhbUser for future user listing page.
* Updates g+ profile info every time a user logs in.
* Updates the unit tests.