### PR TITLE
closes #229: Implement config communication

### DIFF
--- a/client/src/main/webjar/authentication/authentication.config.js
+++ b/client/src/main/webjar/authentication/authentication.config.js
@@ -32,6 +32,7 @@
      * Configures satellizer's Google Oauth.
      */
     function configGoogleOauth(
+        getConfig,
         $authProvider
     ) {
         var redirectUri = getUrlPrefix() + "views/oauth-callback";
@@ -50,14 +51,15 @@
                     "email"
                 ],
                 url: "/auth/google", /* posts to our server */
+                /* TODO: get the redirectUrl from the server */
                 redirectUri: redirectUri, /* redirects to the angular app; this has to match what the server uses */
-                /* TODO: get the clientId and redirectUrl from the server */
-                clientId: "259324353484-f8u4ltb5qko7fltub68dguhs16ae93nr.apps.googleusercontent.com"
+                clientId: getConfig().googleOauthClientId
             }
         );
     }
 
     configGoogleOauth.$inject = [
+        "getConfig",
         "$authProvider"
     ];
 

--- a/client/src/main/webjar/authentication/authentication.module.js
+++ b/client/src/main/webjar/authentication/authentication.module.js
@@ -6,6 +6,7 @@
         [
             "ngMaterial",
             "satellizer",
+            "healthBam.config",
             "healthBam.errorHandling"
         ]
     );

--- a/client/src/test/webjar/karma.conf.js
+++ b/client/src/test/webjar/karma.conf.js
@@ -18,6 +18,7 @@ module.exports = function (config) {
                 "node_modules/angular-material/angular-material.js",
                 "node_modules/ngmap/build/scripts/ng-map.js",
                 "node_modules/satellizer/satellizer.js",
+                "src/test/webjar/mock-config.js",
                 "src/main/**/*.module.js",
                 "src/main/**/*.js",
                 "src/test/**/*.spec.js"

--- a/client/src/test/webjar/mock-config.js
+++ b/client/src/test/webjar/mock-config.js
@@ -1,0 +1,19 @@
+(function (angular) {
+    "use strict";
+
+    var module = angular.module("healthBam.config", []);
+
+    /**
+     * Returns config data (in the real code, this will come from the server).
+     * @returns {{googleOauthClientId: string, urlPrefix: null}}
+     */
+    function getConfig() {
+        return {
+            googleOauthClientId: "test-oauth-client-id",
+            urlPrefix: null
+        };
+    }
+
+    module.constant("getConfig", getConfig);
+
+}(window.angular));

--- a/src/main/java/org/hmhb/authentication/DefaultAuthenticationService.java
+++ b/src/main/java/org/hmhb/authentication/DefaultAuthenticationService.java
@@ -5,6 +5,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import org.hmhb.config.ConfigService;
 import org.hmhb.exception.authentication.ClientIdMismatchException;
 import org.hmhb.exception.oauth.GoogleOauthException;
 import org.hmhb.oauth.GoogleOauthService;
@@ -14,7 +15,6 @@ import org.hmhb.user.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
 import static java.util.Objects.requireNonNull;
@@ -27,7 +27,7 @@ public class DefaultAuthenticationService implements AuthenticationService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAuthenticationService.class);
 
-    private final Environment environment;
+    private final ConfigService configService;
     private final GoogleOauthService googleOauthService;
     private final JwtAuthenticationService jwtAuthenticationService;
     private final UserService userService;
@@ -35,7 +35,7 @@ public class DefaultAuthenticationService implements AuthenticationService {
     /**
      * An injectable constructor.
      *
-     * @param environment the {@link Environment} for config
+     * @param configService the {@link ConfigService} for config
      * @param googleOauthService the {@link GoogleOauthService} to confirm a
      *                           user's email with google
      * @param jwtAuthenticationService the {@link JwtAuthenticationService} to
@@ -45,12 +45,12 @@ public class DefaultAuthenticationService implements AuthenticationService {
      */
     @Autowired
     public DefaultAuthenticationService(
-            @Nonnull Environment environment,
+            @Nonnull ConfigService configService,
             @Nonnull GoogleOauthService googleOauthService,
             @Nonnull JwtAuthenticationService jwtAuthenticationService,
             @Nonnull UserService userService
     ) {
-        this.environment = requireNonNull(environment, "environment cannot be null");
+        this.configService = requireNonNull(configService, "configService cannot be null");
         this.googleOauthService = requireNonNull(googleOauthService, "googleOauthService cannot be null");
         this.jwtAuthenticationService = requireNonNull(jwtAuthenticationService, "jwtAuthenticationService cannot be null");
         this.userService = requireNonNull(userService, "userService cannot be null");
@@ -65,8 +65,8 @@ public class DefaultAuthenticationService implements AuthenticationService {
 
         String email;
 
-        String clientId = environment.getProperty("google.oauth.client.id");
-        String clientSecret = environment.getProperty("google.oauth.client.secret");
+        String clientId = configService.getPublicConfig().getGoogleOauthClientId();
+        String clientSecret = configService.getPrivateConfig().getGoogleOauthSecret();
 
         if (!clientId.equals(request.getClientId())) {
             throw new ClientIdMismatchException(

--- a/src/main/java/org/hmhb/authentication/DefaultJwtAuthenticationService.java
+++ b/src/main/java/org/hmhb/authentication/DefaultJwtAuthenticationService.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import org.hmhb.config.ConfigService;
 import org.hmhb.exception.authentication.AuthHeaderHasTooManyPartsException;
 import org.hmhb.exception.authentication.AuthHeaderMissingTokenException;
 import org.hmhb.exception.authentication.AuthHeaderUnknownException;
@@ -22,7 +23,6 @@ import org.hmhb.user.HmhbUser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
 import static java.util.Objects.requireNonNull;
@@ -35,26 +35,26 @@ public class DefaultJwtAuthenticationService implements JwtAuthenticationService
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAuthenticationService.class);
 
-    private final Environment environment;
+    private final ConfigService configService;
 
     /**
      * An injectable constructor.
      *
-     * @param environment the {@link Environment} to get config from
+     * @param configService the {@link ConfigService} to get config from
      */
     @Autowired
     public DefaultJwtAuthenticationService(
-            @Nonnull Environment environment
+            @Nonnull ConfigService configService
     ) {
-        this.environment = requireNonNull(environment, "environment cannot be null");
+        this.configService = requireNonNull(configService, "configService cannot be null");
     }
 
     private String getDomain() {
-        return environment.getProperty("hmhb.jwt.domain");
+        return configService.getPrivateConfig().getJwtDomain();
     }
 
     private String getSecret() {
-        return environment.getProperty("hmhb.jwt.secret");
+        return configService.getPrivateConfig().getJwtSecret();
     }
 
     private Date getTokenExpirationDate() {

--- a/src/main/java/org/hmhb/config/ConfigController.java
+++ b/src/main/java/org/hmhb/config/ConfigController.java
@@ -1,0 +1,90 @@
+package org.hmhb.config;
+
+import javax.annotation.Nonnull;
+import javax.servlet.http.HttpServletResponse;
+
+import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Spring MVC {@link Controller} for serving our our common configuration
+ * between the client and server in a javascript file (so the client can
+ * load this synchronously and use the data in angular's config phase).
+ */
+@RestController
+public class ConfigController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigController.class);
+
+    private final HttpServletResponse response;
+    private final ConfigService configService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * An injectable constructor.
+     *
+     * @param response the {@link HttpServletResponse} to turn off caching
+     * @param configService the {@link ConfigService} for config
+     * @param objectMapper the {@link ObjectMapper} to convert our config to
+     *                     JSON for the client
+     */
+    @Autowired
+    public ConfigController(
+            @Nonnull HttpServletResponse response,
+            @Nonnull ConfigService configService,
+            @Nonnull ObjectMapper objectMapper
+    ) {
+        this.response = requireNonNull(response, "response cannot be null");
+        this.configService = requireNonNull(configService, "configService cannot be null");
+        this.objectMapper = requireNonNull(objectMapper, "objectMapper cannot be null");
+    }
+
+    /**
+     * Serves our single page app for any sub-views.
+     *
+     * @return our single page app's index.html
+     * @throws JsonProcessingException if the {@link ObjectMapper} failed to
+     * serialize the config
+     */
+    @Timed
+    @RequestMapping(
+            method = RequestMethod.GET,
+            value = "/config.js"
+    )
+    public String getConfigJs() throws JsonProcessingException {
+        LOGGER.debug("getConfigJs called");
+
+        /*
+         * We don't want the browser to treat this like a normal javascript
+         * file.  Instead, we want to disable cache for this because config
+         * is expected to change.  As for max-age vs. no-cache, it looks
+         * like max-age is the better one to use:
+         * http://stackoverflow.com/questions/1046966/whats-the-difference-between-cache-control-max-age-0-and-no-cache
+         */
+        response.setHeader("Cache-Control", "max-age=0, must-revalidate");
+
+        return "(function (angular) {\n"
+                + "    \"use strict\";\n"
+                + "\n"
+                + "    var module = angular.module(\"healthBam.config\", []);\n"
+                + "\n"
+                + "    function getConfig() {\n"
+                + "        return " + objectMapper.writeValueAsString(configService.getPublicConfig()) + ";\n"
+                + "    }\n"
+                + "\n"
+                + "    module.constant(\"getConfig\", getConfig);\n"
+                + "\n"
+                + "}(window.angular));\n";
+    }
+
+}

--- a/src/main/java/org/hmhb/config/ConfigService.java
+++ b/src/main/java/org/hmhb/config/ConfigService.java
@@ -1,0 +1,23 @@
+package org.hmhb.config;
+
+/**
+ * Service consolidate where to get config.
+ */
+public interface ConfigService {
+
+    /**
+     * Returns the config relevant and allowed to be shared with the client.
+     *
+     * @return the client-sharable config
+     */
+    PublicConfig getPublicConfig();
+
+    /**
+     * Returns the config too sensitive to share with the client, or irrelevant
+     * to the client.
+     *
+     * @return the non-client-sharable config
+     */
+    PrivateConfig getPrivateConfig();
+
+}

--- a/src/main/java/org/hmhb/config/DefaultConfigService.java
+++ b/src/main/java/org/hmhb/config/DefaultConfigService.java
@@ -1,0 +1,53 @@
+package org.hmhb.config;
+
+import javax.annotation.Nonnull;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Default implementation of {@link ConfigService}.
+ */
+@Service
+public class DefaultConfigService implements ConfigService {
+
+    private final PublicConfig publicConfig;
+    private final PrivateConfig privateConfig;
+
+    /**
+     * An injectable constructor.
+     *
+     * @param environment the {@link Environment} to get config from
+     */
+    @Autowired
+    public DefaultConfigService(
+            @Nonnull Environment environment
+    ) {
+        requireNonNull(environment, "environment cannot be null");
+
+        this.publicConfig = new PublicConfig(
+                environment.getProperty("google.oauth.client.id"),
+                environment.getProperty("hmhb.url.prefix")
+        );
+
+        this.privateConfig = new PrivateConfig(
+                environment.getProperty("google.oauth.client.secret"),
+                environment.getProperty("hmhb.jwt.domain"),
+                environment.getProperty("hmhb.jwt.secret")
+        );
+    }
+
+    @Override
+    public PublicConfig getPublicConfig() {
+        return publicConfig;
+    }
+
+    @Override
+    public PrivateConfig getPrivateConfig() {
+        return privateConfig;
+    }
+
+}

--- a/src/main/java/org/hmhb/config/PrivateConfig.java
+++ b/src/main/java/org/hmhb/config/PrivateConfig.java
@@ -1,0 +1,83 @@
+package org.hmhb.config;
+
+import javax.annotation.Nonnull;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Object to hold config that is only for the server (either explicitly cannot
+ * be shared with the client, or it is irrelevant to the client).
+ */
+public class PrivateConfig {
+
+    private final String googleOauthSecret;
+    private final String jwtDomain;
+    private final String jwtSecret;
+
+    /**
+     * Constructs a {@link PrivateConfig}.
+     *
+     * @param googleOauthSecret the google oauth2 client secret
+     * @param jwtDomain the base domain used as issuer and audience for our
+     *                  JWT tokens
+     * @param jwtSecret the secret to sign our JWT tokens
+     */
+    public PrivateConfig(
+            @Nonnull String googleOauthSecret,
+            @Nonnull String jwtDomain,
+            @Nonnull String jwtSecret
+    ) {
+        this.googleOauthSecret = requireNonNull(googleOauthSecret, "googleOauthSecret cannot be null");
+        this.jwtDomain = requireNonNull(jwtDomain, "jwtDomain cannot be null");
+        this.jwtSecret = requireNonNull(jwtSecret, "jwtSecret cannot be null");
+    }
+
+    /**
+     * Returns the Oauth2 client secret for our server's communication with
+     * google.
+     *
+     * @return the google oauth2 client secret
+     */
+    public String getGoogleOauthSecret() {
+        return googleOauthSecret;
+    }
+
+    /**
+     * Returns the base domain we are using as the issuer and audience for our
+     * JWT tokens.
+     *
+     * @return the base domain used as issuer and audience for our JWT tokens
+     */
+    public String getJwtDomain() {
+        return jwtDomain;
+    }
+
+    /**
+     * Returns the secret we are using to sign our JWT tokens.
+     *
+     * @return the secret to sign our JWT tokens
+     */
+    public String getJwtSecret() {
+        return jwtSecret;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/org/hmhb/config/PublicConfig.java
+++ b/src/main/java/org/hmhb/config/PublicConfig.java
@@ -1,0 +1,68 @@
+package org.hmhb.config;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * DTO to hold config that is ok to share with the client.
+ */
+public class PublicConfig {
+
+    private final String googleOauthClientId;
+    private final String urlPrefix;
+
+    /**
+     * Constructs a {@link PublicConfig}.
+     *
+     * @param googleOauthClientId the google oauth2 client ID
+     * @param urlPrefix the configured url prefix
+     */
+    public PublicConfig(
+            @Nonnull String googleOauthClientId,
+            @Nullable String urlPrefix
+    ) {
+        this.googleOauthClientId = requireNonNull(googleOauthClientId, "googleOauthClientId cannot be null");
+        this.urlPrefix = urlPrefix;
+    }
+
+    /**
+     * Returns the Oauth2 client ID for our server's communication with google.
+     *
+     * @return the google oauth2 client ID
+     */
+    public String getGoogleOauthClientId() {
+        return googleOauthClientId;
+    }
+
+    /**
+     * Returns the configured url prefix (useful for allowing your local
+     * instances to generate external KML links for google maps.
+     *
+     * @return the configured url prefix
+     */
+    public String getUrlPrefix() {
+        return urlPrefix;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/org/hmhb/url/DefaultUrlService.java
+++ b/src/main/java/org/hmhb/url/DefaultUrlService.java
@@ -5,8 +5,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import com.codahale.metrics.annotation.Timed;
 import org.apache.commons.lang3.StringUtils;
+import org.hmhb.config.ConfigService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
 import static java.util.Objects.requireNonNull;
@@ -18,29 +18,30 @@ import static java.util.Objects.requireNonNull;
 public class DefaultUrlService implements UrlService {
 
     private final HttpServletRequest request;
-    private final Environment environment;
+    private final ConfigService configService;
 
     /**
      * An injectable constructor.
      *
      * @param request the {@link HttpServletRequest} to get protocol and port
      *                info
-     * @param environment the {@link Environment} to get config info
+     * @param configService the {@link org.hmhb.config.ConfigService} to get
+     *                      config info
      */
     @Autowired
     public DefaultUrlService(
             @Nonnull HttpServletRequest request,
-            @Nonnull Environment environment
+            @Nonnull ConfigService configService
     ) {
         this.request = requireNonNull(request, "request cannot be null");
-        this.environment = requireNonNull(environment, "environment cannot be null");
+        this.configService = requireNonNull(configService, "configService cannot be null");
     }
 
     @Timed
     @Override
     public String getUrlPrefix() {
 
-        String configuredUrlPrefix = environment.getProperty("hmhb.url.prefix");
+        String configuredUrlPrefix = configService.getPublicConfig().getUrlPrefix();
 
         if (StringUtils.isNotBlank(configuredUrlPrefix)) {
             return configuredUrlPrefix;

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -26,6 +26,22 @@ INSERT INTO hmhb_user (
     'jlgett@gmail.com',
     TRUE
 );
+
+INSERT INTO hmhb_user (
+    email,
+    admin
+) VALUES (
+    'jslide07@gmail.com',
+    TRUE
+);
+
+INSERT INTO hmhb_user (
+    email,
+    admin
+) VALUES (
+    'contactkaranpratap@gmail.com',
+    TRUE
+);
 /**********************************
  * End Users.
  **********************************/

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -52,6 +52,9 @@
         <!-- TODO: API KEY? -->
         <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyA_WiLcsn_2Z26Jo8eZwPOxl74zSkjhSFQ"></script>
 
+        <!-- Load the server's public config. -->
+        <script src="/config.js"></script>
+
         <!-- Load healthBam. -->
         <script src="/webjars/hmhb-client/1.0-SNAPSHOT/health-bam.all.min.js"></script>
 

--- a/src/test/java/org/hmhb/authentication/DefaultAuthenticationServiceTest.java
+++ b/src/test/java/org/hmhb/authentication/DefaultAuthenticationServiceTest.java
@@ -5,6 +5,9 @@ import java.io.IOException;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
 import com.google.api.services.plus.model.Person;
+import org.hmhb.config.ConfigService;
+import org.hmhb.config.PrivateConfig;
+import org.hmhb.config.PublicConfig;
 import org.hmhb.exception.authentication.ClientIdMismatchException;
 import org.hmhb.exception.oauth.GoogleOauthException;
 import org.hmhb.oauth.GoogleOauthService;
@@ -13,7 +16,6 @@ import org.hmhb.user.HmhbUser;
 import org.hmhb.user.UserService;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.core.env.Environment;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -31,7 +33,7 @@ public class DefaultAuthenticationServiceTest {
     private static final String PREFIX = "test-prefix/views/oauth-callback";
     private static final String TOKEN = "test-token";
 
-    private Environment environment;
+    private ConfigService configService;
     private GoogleOauthService googleOauthService;
     private JwtAuthenticationService jwtAuthService;
     private UserService userService;
@@ -40,12 +42,12 @@ public class DefaultAuthenticationServiceTest {
 
     @Before
     public void setUp() throws Exception {
-        environment = mock(Environment.class);
+        configService = mock(ConfigService.class);
         googleOauthService = mock(GoogleOauthService.class);
         jwtAuthService = mock(JwtAuthenticationService.class);
         userService = mock(UserService.class);
         toTest = new DefaultAuthenticationService(
-                environment,
+                configService,
                 googleOauthService,
                 jwtAuthService,
                 userService
@@ -62,9 +64,12 @@ public class DefaultAuthenticationServiceTest {
                 gPlusProfile
         );
 
+        PublicConfig publicConfig = new PublicConfig(CLIENT_ID, null);
+        PrivateConfig privateConfig = new PrivateConfig(CLIENT_SECRET, "jwtDomain", "jwtSecret");
+
         /* Train the mocks. */
-        when(environment.getProperty("google.oauth.client.id")).thenReturn(CLIENT_ID);
-        when(environment.getProperty("google.oauth.client.secret")).thenReturn(CLIENT_SECRET);
+        when(configService.getPublicConfig()).thenReturn(publicConfig);
+        when(configService.getPrivateConfig()).thenReturn(privateConfig);
         when(
                 googleOauthService.getUserDataFromGoogle(
                         CLIENT_ID,

--- a/src/test/java/org/hmhb/authentication/DefaultJwtAuthenticationServiceTest.java
+++ b/src/test/java/org/hmhb/authentication/DefaultJwtAuthenticationServiceTest.java
@@ -3,13 +3,15 @@ package org.hmhb.authentication;
 import javax.servlet.http.HttpServletRequest;
 
 import io.jsonwebtoken.SignatureException;
+import org.hmhb.config.ConfigService;
+import org.hmhb.config.PrivateConfig;
+import org.hmhb.config.PublicConfig;
 import org.hmhb.exception.authentication.AuthHeaderHasTooManyPartsException;
 import org.hmhb.exception.authentication.AuthHeaderMissingTokenException;
 import org.hmhb.exception.authentication.AuthHeaderUnknownException;
 import org.hmhb.user.HmhbUser;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.core.env.Environment;
 
 import static org.mockito.Mockito.*;
 
@@ -24,15 +26,15 @@ public class DefaultJwtAuthenticationServiceTest {
     private static final String USER_EMAIL = "john.doe@mailinator.com";
 
     private HttpServletRequest request;
-    private Environment environment;
+    private ConfigService configService;
 
     private DefaultJwtAuthenticationService toTest;
 
     @Before
     public void setUp() throws Exception {
-        environment = mock(Environment.class);
+        configService = mock(ConfigService.class);
         request = mock(HttpServletRequest.class);
-        toTest = new DefaultJwtAuthenticationService(environment);
+        toTest = new DefaultJwtAuthenticationService(configService);
     }
 
     @Test
@@ -42,16 +44,17 @@ public class DefaultJwtAuthenticationServiceTest {
         user.setEmail(USER_EMAIL);
         user.setAdmin(false);
 
+        PublicConfig publicConfig = new PublicConfig("oauthClientId", null);
+        PrivateConfig privateConfig = new PrivateConfig("oauthClientSecret", TEST_DOMAIN, TEST_SECRET);
+
         /* Train the config. */
-        when(environment.getProperty("hmhb.jwt.domain")).thenReturn(TEST_DOMAIN);
-        when(environment.getProperty("hmhb.jwt.secret")).thenReturn(TEST_SECRET);
+        when(configService.getPublicConfig()).thenReturn(publicConfig);
+        when(configService.getPrivateConfig()).thenReturn(privateConfig);
 
         /* Make the generate call. */
         String token = toTest.generateJwtToken(user);
 
         /* Train the mocks. */
-        when(environment.getProperty("hmhb.jwt.domain")).thenReturn(TEST_DOMAIN);
-        when(environment.getProperty("hmhb.jwt.secret")).thenReturn(TEST_SECRET);
         when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
 
         /* Make the validate call. */
@@ -68,9 +71,12 @@ public class DefaultJwtAuthenticationServiceTest {
         user.setEmail(USER_EMAIL);
         user.setAdmin(false);
 
+        PublicConfig publicConfig = new PublicConfig("oauthClientId", null);
+        PrivateConfig privateConfig = new PrivateConfig("oauthClientSecret", TEST_DOMAIN, TEST_SECRET);
+
         /* Train the config. */
-        when(environment.getProperty("hmhb.jwt.domain")).thenReturn(TEST_DOMAIN);
-        when(environment.getProperty("hmhb.jwt.secret")).thenReturn(TEST_SECRET);
+        when(configService.getPublicConfig()).thenReturn(publicConfig);
+        when(configService.getPrivateConfig()).thenReturn(privateConfig);
 
         /* Make the generate call. */
         String token = toTest.generateJwtToken(user);
@@ -115,9 +121,12 @@ public class DefaultJwtAuthenticationServiceTest {
         user.setEmail(USER_EMAIL);
         user.setAdmin(false);
 
+        PublicConfig publicConfig = new PublicConfig("oauthClientId", null);
+        PrivateConfig privateConfig = new PrivateConfig("oauthClientSecret", TEST_DOMAIN, TEST_SECRET);
+
         /* Train the config. */
-        when(environment.getProperty("hmhb.jwt.domain")).thenReturn(TEST_DOMAIN);
-        when(environment.getProperty("hmhb.jwt.secret")).thenReturn(TEST_SECRET);
+        when(configService.getPublicConfig()).thenReturn(publicConfig);
+        when(configService.getPrivateConfig()).thenReturn(privateConfig);
 
         /* Make the generate call. */
         String token = toTest.generateJwtToken(user);
@@ -136,9 +145,12 @@ public class DefaultJwtAuthenticationServiceTest {
         user.setEmail(USER_EMAIL);
         user.setAdmin(false);
 
+        PublicConfig publicConfig = new PublicConfig("oauthClientId", null);
+        PrivateConfig privateConfig = new PrivateConfig("oauthClientSecret", TEST_DOMAIN, TEST_SECRET);
+
         /* Train the config. */
-        when(environment.getProperty("hmhb.jwt.domain")).thenReturn(TEST_DOMAIN);
-        when(environment.getProperty("hmhb.jwt.secret")).thenReturn(TEST_SECRET);
+        when(configService.getPublicConfig()).thenReturn(publicConfig);
+        when(configService.getPrivateConfig()).thenReturn(privateConfig);
 
         /* Make the generate call. */
         String token = toTest.generateJwtToken(user);

--- a/src/test/java/org/hmhb/config/ConfigControllerTest.java
+++ b/src/test/java/org/hmhb/config/ConfigControllerTest.java
@@ -1,0 +1,60 @@
+package org.hmhb.config;
+
+import javax.servlet.http.HttpServletResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link ConfigController}.
+ */
+public class ConfigControllerTest {
+
+    private HttpServletResponse response;
+    private ConfigService service;
+
+    private ConfigController toTest;
+
+    @Before
+    public void setUp() throws Exception {
+        response = mock(HttpServletResponse.class);
+        service = mock(ConfigService.class);
+        ObjectMapper mapper = new ObjectMapper();
+
+        toTest = new ConfigController(
+                response,
+                service,
+                mapper
+        );
+    }
+
+    @Test
+    public void testGetConfigJs() throws Exception {
+
+        String oauthClientId = "test-oauth-client-id";
+        String urlPrefix = "test-url-prefix";
+
+        PublicConfig publicConfig = new PublicConfig(
+                oauthClientId,
+                urlPrefix
+        );
+
+        /* Train the mocks. */
+        when(service.getPublicConfig()).thenReturn(publicConfig);
+
+        /* Make the call. */
+        String actual = toTest.getConfigJs();
+
+        /* Verify the results. */
+        assertTrue(actual.contains(oauthClientId));
+        assertTrue(actual.contains(urlPrefix));
+
+        /* Verify the response wont be cached. */
+        verify(response).setHeader("Cache-Control", "max-age=0, must-revalidate");
+    }
+
+}

--- a/src/test/java/org/hmhb/config/DefaultConfigServiceTest.java
+++ b/src/test/java/org/hmhb/config/DefaultConfigServiceTest.java
@@ -1,0 +1,66 @@
+package org.hmhb.config;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.env.Environment;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link DefaultConfigService}.
+ */
+public class DefaultConfigServiceTest {
+
+    private static final String OAUTH_ID = "test-oauth-client-id";
+    private static final String OAUTH_SECRET = "test-oauth-client-secret";
+    private static final String URL_PREFIX = "test-url-prefix";
+    private static final String JWT_DOMAIN = "test-jwt-domain";
+    private static final String JWT_SECRET = "test-jwt-secret";
+
+    private DefaultConfigService toTest;
+
+    @Before
+    public void setUp() throws Exception {
+        Environment environment = mock(Environment.class);
+
+        /* Train the mocks. */
+        when(environment.getProperty("google.oauth.client.id")).thenReturn(OAUTH_ID);
+        when(environment.getProperty("google.oauth.client.secret")).thenReturn(OAUTH_SECRET);
+        when(environment.getProperty("hmhb.url.prefix")).thenReturn(URL_PREFIX);
+        when(environment.getProperty("hmhb.jwt.domain")).thenReturn(JWT_DOMAIN);
+        when(environment.getProperty("hmhb.jwt.secret")).thenReturn(JWT_SECRET);
+
+        toTest = new DefaultConfigService(environment);
+    }
+
+    @Test
+    public void testGetPublicConfig() throws Exception {
+        PublicConfig expected = new PublicConfig(
+                OAUTH_ID,
+                URL_PREFIX
+        );
+
+        /* Make the call. */
+        PublicConfig actual = toTest.getPublicConfig();
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetPrivateConfig() throws Exception {
+        PrivateConfig expected = new PrivateConfig(
+                OAUTH_SECRET,
+                JWT_DOMAIN,
+                JWT_SECRET
+        );
+
+        /* Make the call. */
+        PrivateConfig actual = toTest.getPrivateConfig();
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+}

--- a/src/test/java/org/hmhb/url/DefaultUrlServiceTest.java
+++ b/src/test/java/org/hmhb/url/DefaultUrlServiceTest.java
@@ -2,9 +2,11 @@ package org.hmhb.url;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.hmhb.config.ConfigService;
+import org.hmhb.config.PrivateConfig;
+import org.hmhb.config.PublicConfig;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.core.env.Environment;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -15,23 +17,29 @@ import static org.mockito.Mockito.*;
 public class DefaultUrlServiceTest {
 
     private HttpServletRequest request;
-    private Environment environment;
+    private ConfigService configService;
 
     private DefaultUrlService toTest;
 
     @Before
     public void setUp() throws Exception {
         request = mock(HttpServletRequest.class);
-        environment = mock(Environment.class);
-        toTest = new DefaultUrlService(request, environment);
+        configService = mock(ConfigService.class);
+        toTest = new DefaultUrlService(request, configService);
     }
 
     @Test
     public void testGetUrlPrefix() throws Exception {
         String expected = "https://hmhb.herokuapp.com:443";
 
+        PublicConfig publicConfig = new PublicConfig("oauthClientId", null);
+        PrivateConfig privateConfig = new PrivateConfig("oauthClientSecret", "jwtDomain", "jwtSecret");
+
+        /* Train the config. */
+        when(configService.getPublicConfig()).thenReturn(publicConfig);
+        when(configService.getPrivateConfig()).thenReturn(privateConfig);
+
         /* Train the mocks. */
-        when(environment.getProperty("hmhb.url.prefix")).thenReturn(null);
         when(request.getScheme()).thenReturn("https");
         when(request.getServerName()).thenReturn("hmhb.herokuapp.com");
         when(request.getServerPort()).thenReturn(443);
@@ -47,8 +55,14 @@ public class DefaultUrlServiceTest {
     public void testGetUrlPrefixNoPortSpecified() throws Exception {
         String expected = "https://hmhb.herokuapp.com";
 
+        PublicConfig publicConfig = new PublicConfig("oauthClientId", null);
+        PrivateConfig privateConfig = new PrivateConfig("oauthClientSecret", "jwtDomain", "jwtSecret");
+
+        /* Train the config. */
+        when(configService.getPublicConfig()).thenReturn(publicConfig);
+        when(configService.getPrivateConfig()).thenReturn(privateConfig);
+
         /* Train the mocks. */
-        when(environment.getProperty("hmhb.url.prefix")).thenReturn(null);
         when(request.getScheme()).thenReturn("https");
         when(request.getServerName()).thenReturn("hmhb.herokuapp.com");
         when(request.getServerPort()).thenReturn(-1);
@@ -64,8 +78,14 @@ public class DefaultUrlServiceTest {
     public void testGetUrlPrefixConfigOverride() throws Exception {
         String expected = "https://hmhb.herokuapp.com";
 
+        PublicConfig publicConfig = new PublicConfig("oauthClientId", expected);
+        PrivateConfig privateConfig = new PrivateConfig("oauthClientSecret", "jwtDomain", "jwtSecret");
+
+        /* Train the config. */
+        when(configService.getPublicConfig()).thenReturn(publicConfig);
+        when(configService.getPrivateConfig()).thenReturn(privateConfig);
+
         /* Train the mocks. */
-        when(environment.getProperty("hmhb.url.prefix")).thenReturn(expected);
         when(request.getScheme()).thenReturn("http");
         when(request.getServerName()).thenReturn("localhost");
         when(request.getServerPort()).thenReturn(8080);
@@ -81,8 +101,14 @@ public class DefaultUrlServiceTest {
     public void testGetUrlPrefixConfigOverrideIsEmpty() throws Exception {
         String expected = "http://localhost:8080";
 
+        PublicConfig publicConfig = new PublicConfig("oauthClientId", "");
+        PrivateConfig privateConfig = new PrivateConfig("oauthClientSecret", "jwtDomain", "jwtSecret");
+
+        /* Train the config. */
+        when(configService.getPublicConfig()).thenReturn(publicConfig);
+        when(configService.getPrivateConfig()).thenReturn(privateConfig);
+
         /* Train the mocks. */
-        when(environment.getProperty("hmhb.url.prefix")).thenReturn("");
         when(request.getScheme()).thenReturn("http");
         when(request.getServerName()).thenReturn("localhost");
         when(request.getServerPort()).thenReturn(8080);
@@ -98,8 +124,14 @@ public class DefaultUrlServiceTest {
     public void testGetUrlPrefixConfigOverrideIsSpace() throws Exception {
         String expected = "http://localhost:8080";
 
+        PublicConfig publicConfig = new PublicConfig("oauthClientId", "   ");
+        PrivateConfig privateConfig = new PrivateConfig("oauthClientSecret", "jwtDomain", "jwtSecret");
+
+        /* Train the config. */
+        when(configService.getPublicConfig()).thenReturn(publicConfig);
+        when(configService.getPrivateConfig()).thenReturn(privateConfig);
+
         /* Train the mocks. */
-        when(environment.getProperty("hmhb.url.prefix")).thenReturn("   ");
         when(request.getScheme()).thenReturn("http");
         when(request.getServerName()).thenReturn("localhost");
         when(request.getServerPort()).thenReturn(8080);


### PR DESCRIPTION
* Adds a way for the server to send config to the client.
* Pushes google oauth client ID into this config.
* Refactors server config into the same place as "public" client config.
* Updates the unit tests.
* Adds John and KP as admins.