### PR TITLE
closes #238: Add user management REST calls

### DIFF
--- a/client/src/main/webjar/app.js
+++ b/client/src/main/webjar/app.js
@@ -69,7 +69,8 @@
             "healthBam.map",
             "healthBam.programDetails",
             "healthBam.organizationList",
-            "healthBam.organizationDetails"
+            "healthBam.organizationDetails",
+            "healthBam.user"
         ]
     );
 

--- a/client/src/main/webjar/user/user.module.js
+++ b/client/src/main/webjar/user/user.module.js
@@ -1,0 +1,11 @@
+(function (angular) {
+    "use strict";
+
+    angular.module(
+        "healthBam.user",
+        [
+            "ngResource"
+        ]
+    );
+
+}(window.angular));

--- a/client/src/main/webjar/user/user.resource.js
+++ b/client/src/main/webjar/user/user.resource.js
@@ -1,0 +1,32 @@
+(function (angular) {
+    "use strict";
+
+    var module = angular.module("healthBam.user");
+
+    /**
+     * Resource for users.
+     * @param $resource service.
+     * @returns new $resource instance for users.
+     * @constructor
+     */
+    function User(
+        $resource
+    ) {
+        return $resource(
+            "api/users/:id",
+            {
+                id: "@id"
+            }
+        );
+    }
+
+    User.$inject = [
+        "$resource"
+    ];
+
+    module.factory(
+        "User",
+        User
+    );
+
+}(window.angular));

--- a/client/src/test/webjar/user/user.resource.spec.js
+++ b/client/src/test/webjar/user/user.resource.spec.js
@@ -1,0 +1,415 @@
+(function (angular, jasmine, beforeEach, describe, it) {
+    "use strict";
+
+    /* All of the healthBam.user module's tests. */
+    describe("healthBam.user module", function () {
+
+        beforeEach(
+            function () {
+                /* Load the module to test. */
+                angular.mock.module("healthBam.user");
+            }
+        );
+
+        describe("User $resource", function () {
+
+            var User,
+                $httpBackend,
+                endpoint,
+                handlers;
+
+            /**
+             * Helper function for creating a User instance.
+             * @param {number} id of the User.
+             * @returns User instance.
+             */
+            function createUser(id) {
+                return new User(
+                    {
+                        id: id
+                    }
+                );
+            }
+
+            beforeEach(
+                function () {
+
+                    endpoint = "api/users";
+
+                    /* Inject dependencies. */
+                    angular.mock.inject(
+                        function ($injector) {
+                            User = $injector.get("User");
+                            $httpBackend = $injector.get("$httpBackend");
+                        }
+                    );
+
+                    /* Create handlers spy for promise tracking. */
+                    handlers = jasmine.createSpyObj(
+                        "handlers",
+                        [
+                            "onSuccess",
+                            "onError"
+                        ]
+                    );
+
+                }
+            );
+
+            describe("query", function () {
+
+                it("should be exposed", function () {
+                    expect(User.query).toEqual(jasmine.any(Function));
+                });
+
+                it("should GET to endpoint and return array on success", function () {
+
+                    var actual,
+                        expected = [],
+                        promise;
+
+                    expected.push(
+                        createUser(1)
+                    );
+                    expected.push(
+                        createUser(2)
+                    );
+                    expected.push(
+                        createUser(3)
+                    );
+
+                    $httpBackend.expectGET(
+                        endpoint
+                    ).respond(
+                        angular.toJson(expected)
+                    );
+
+                    actual = User.query();
+
+                    promise = actual.$promise;
+
+                    promise.then(handlers.onSuccess);
+                    promise.catch(handlers.onError);
+
+                    $httpBackend.flush();
+
+                    expect(
+                        actual
+                    ).toEqual(
+                        jasmine.objectContaining(expected)
+                    );
+
+                    expect(handlers.onSuccess).toHaveBeenCalled();
+                    expect(handlers.onError).not.toHaveBeenCalled();
+                });
+
+                it("should GET to endpoint and call catch on error response", function () {
+
+                    var actual,
+                        promise;
+
+                    $httpBackend.expectGET(
+                        endpoint
+                    ).respond(
+                        418
+                    );
+
+                    actual = User.query();
+
+                    promise = actual.$promise;
+
+                    promise.then(handlers.onSuccess);
+                    promise.catch(handlers.onError);
+
+                    $httpBackend.flush();
+
+                    expect(handlers.onSuccess).not.toHaveBeenCalled();
+                    expect(handlers.onError).toHaveBeenCalled();
+                });
+
+            });
+
+            describe("get", function () {
+
+                it("should be exposed", function () {
+                    expect(User.get).toEqual(jasmine.any(Function));
+                });
+
+                it("should GET to endpoint and return User on success", function () {
+
+                    var actual,
+                        expected,
+                        promise,
+                        userId = 789;
+
+                    expected = createUser(userId);
+
+                    $httpBackend.expectGET(
+                        endpoint + "/" + userId
+                    ).respond(
+                        angular.toJson(expected)
+                    );
+
+                    actual = User.get(
+                        {
+                            id: userId
+                        }
+                    );
+
+                    promise = actual.$promise;
+
+                    promise.then(handlers.onSuccess);
+                    promise.catch(handlers.onError);
+
+                    $httpBackend.flush();
+
+                    expect(
+                        actual
+                    ).toEqual(
+                        jasmine.objectContaining(expected)
+                    );
+
+                    expect(handlers.onSuccess).toHaveBeenCalled();
+                    expect(handlers.onError).not.toHaveBeenCalled();
+                });
+
+                it("should GET to endpoint and call catch on error response", function () {
+
+                    var actual,
+                        promise,
+                        userId = 789;
+
+                    $httpBackend.expectGET(
+                        endpoint + "/" + userId
+                    ).respond(
+                        418
+                    );
+
+                    actual = User.get(
+                        {
+                            id: userId
+                        }
+                    );
+
+                    promise = actual.$promise;
+
+                    promise.then(handlers.onSuccess);
+                    promise.catch(handlers.onError);
+
+                    $httpBackend.flush();
+
+                    expect(handlers.onSuccess).not.toHaveBeenCalled();
+                    expect(handlers.onError).toHaveBeenCalled();
+                });
+
+            });
+
+            describe("$save", function () {
+
+                it("should be exposed", function () {
+
+                    var user = createUser(789);
+
+                    expect(user.$save).toEqual(jasmine.any(Function));
+                });
+
+                it("should POST new User to endpoint and update it on success", function () {
+
+                    var user,
+                        expected,
+                        promise;
+
+                    user = new User(
+                        {
+                            email: "test@mailinator.com"
+                        }
+                    );
+
+                    expected = angular.copy(user);
+                    expected.id = 789;
+
+                    $httpBackend.expectPOST(
+                        endpoint
+                    ).respond(
+                        angular.toJson(expected)
+                    );
+
+                    promise = user.$save();
+
+                    promise.then(handlers.onSuccess);
+                    promise.catch(handlers.onError);
+
+                    $httpBackend.flush();
+
+                    expect(
+                        user
+                    ).toEqual(
+                        jasmine.objectContaining(expected)
+                    );
+                    expect(handlers.onSuccess).toHaveBeenCalled();
+                    expect(handlers.onError).not.toHaveBeenCalled();
+                });
+
+                it("should POST new User to endpoint and call catch on error response", function () {
+
+                    var user,
+                        promise;
+
+                    user = new User(
+                        {
+                            email: "test@mailinator.com"
+                        }
+                    );
+
+                    $httpBackend.expectPOST(
+                        endpoint
+                    ).respond(
+                        418
+                    );
+
+                    promise = user.$save();
+
+                    promise.then(handlers.onSuccess);
+                    promise.catch(handlers.onError);
+
+                    $httpBackend.flush();
+
+                    expect(handlers.onSuccess).not.toHaveBeenCalled();
+                    expect(handlers.onError).toHaveBeenCalled();
+                });
+
+                it("should POST existing User to endpoint and update it on success", function () {
+
+                    var user,
+                        userId = 789,
+                        expected,
+                        promise;
+
+                    user = createUser(userId);
+
+                    expected = angular.copy(user);
+                    expected.email = "old.test@mailinator.com";
+
+                    $httpBackend.expectPOST(
+                        endpoint + "/" + userId
+                    ).respond(
+                        angular.toJson(expected)
+                    );
+
+                    promise = user.$save();
+
+                    promise.then(handlers.onSuccess);
+                    promise.catch(handlers.onError);
+
+                    $httpBackend.flush();
+
+                    expect(
+                        user
+                    ).toEqual(
+                        jasmine.objectContaining(expected)
+                    );
+                    expect(handlers.onSuccess).toHaveBeenCalled();
+                    expect(handlers.onError).not.toHaveBeenCalled();
+                });
+
+                it("should POST existing User to endpoint and call catch on error response", function () {
+
+                    var user,
+                        userId = 789,
+                        promise;
+
+                    user = createUser(userId);
+
+                    $httpBackend.expectPOST(
+                        endpoint + "/" + userId
+                    ).respond(
+                        418
+                    );
+
+                    promise = user.$save();
+
+                    promise.then(handlers.onSuccess);
+                    promise.catch(handlers.onError);
+
+                    $httpBackend.flush();
+
+                    expect(handlers.onSuccess).not.toHaveBeenCalled();
+                    expect(handlers.onError).toHaveBeenCalled();
+                });
+
+            });
+
+            describe("$delete", function () {
+
+                it("should be exposed", function () {
+
+                    var user = createUser(789);
+
+                    expect(user.$delete).toEqual(jasmine.any(Function));
+                });
+
+                it("should DELETE existing User to endpoint and update it on success", function () {
+
+                    var user,
+                        userId = 789,
+                        expected,
+                        promise;
+
+                    user = createUser(userId);
+
+                    expected = angular.copy(user);
+
+                    $httpBackend.expectDELETE(
+                        endpoint + "/" + userId
+                    ).respond(
+                        angular.toJson(expected)
+                    );
+
+                    promise = user.$delete();
+
+                    promise.then(handlers.onSuccess);
+                    promise.catch(handlers.onError);
+
+                    $httpBackend.flush();
+
+                    expect(
+                        user
+                    ).toEqual(
+                        jasmine.objectContaining(expected)
+                    );
+                    expect(handlers.onSuccess).toHaveBeenCalled();
+                    expect(handlers.onError).not.toHaveBeenCalled();
+                });
+
+                it("should DELETE existing User to endpoint and call catch on error response", function () {
+
+                    var user,
+                        userId = 789,
+                        promise;
+
+                    user = createUser(userId);
+
+                    $httpBackend.expectDELETE(
+                        endpoint + "/" + userId
+                    ).respond(
+                        418
+                    );
+
+                    promise = user.$delete();
+
+                    promise.then(handlers.onSuccess);
+                    promise.catch(handlers.onError);
+
+                    $httpBackend.flush();
+
+                    expect(handlers.onSuccess).not.toHaveBeenCalled();
+                    expect(handlers.onError).toHaveBeenCalled();
+                });
+
+            });
+
+        });
+
+    });
+
+}(window.angular, window.jasmine, window.beforeEach, window.describe, window.it));

--- a/src/main/java/org/hmhb/exception/user/UserCannotDeleteSuperAdminException.java
+++ b/src/main/java/org/hmhb/exception/user/UserCannotDeleteSuperAdminException.java
@@ -1,0 +1,17 @@
+package org.hmhb.exception.user;
+
+import org.hmhb.exception.NotAuthorizedException;
+
+/**
+ * An exception to indicate that the super-admin cannot be deleted.
+ */
+public class UserCannotDeleteSuperAdminException extends NotAuthorizedException {
+
+    /**
+     * Constructs a {@link UserCannotDeleteSuperAdminException}.
+     */
+    public UserCannotDeleteSuperAdminException() {
+        super("Super admins cannot be deleted!");
+    }
+
+}

--- a/src/main/java/org/hmhb/exception/user/UserEmailRequiredException.java
+++ b/src/main/java/org/hmhb/exception/user/UserEmailRequiredException.java
@@ -1,0 +1,17 @@
+package org.hmhb.exception.user;
+
+import org.hmhb.exception.BadRequestException;
+
+/**
+ * An exception to indicate that a user must have an email.
+ */
+public class UserEmailRequiredException extends BadRequestException {
+
+    /**
+     * Constructs a {@link UserEmailRequiredException}.
+     */
+    public UserEmailRequiredException() {
+        super("A user must have an email!");
+    }
+
+}

--- a/src/main/java/org/hmhb/exception/user/UserIdMismatchException.java
+++ b/src/main/java/org/hmhb/exception/user/UserIdMismatchException.java
@@ -1,0 +1,24 @@
+package org.hmhb.exception.user;
+
+import org.hmhb.exception.BadRequestException;
+
+/**
+ * An exception to indicate that the request's user IDs didn't match
+ * (one from the path, one from the body).
+ */
+public class UserIdMismatchException extends BadRequestException {
+
+    /**
+     * Constructs an {@link UserIdMismatchException}.
+     *
+     * @param pathUserId the ID passed in the url path
+     * @param bodyUserId the ID passed in the http JSON body
+     */
+    public UserIdMismatchException(
+            long pathUserId,
+            Long bodyUserId
+    ) {
+        super("User IDs didn't match! pathId=" + pathUserId + ", bodyId=" + bodyUserId);
+    }
+
+}

--- a/src/main/java/org/hmhb/exception/user/UserNonAdminCannotEscalateToAdminException.java
+++ b/src/main/java/org/hmhb/exception/user/UserNonAdminCannotEscalateToAdminException.java
@@ -1,0 +1,18 @@
+package org.hmhb.exception.user;
+
+import org.hmhb.exception.NotAuthorizedException;
+
+/**
+ * An exception to indicate that a non-admin tried to modify their profile to
+ * be an admin.
+ */
+public class UserNonAdminCannotEscalateToAdminException extends NotAuthorizedException {
+
+    /**
+     * Constructs a {@link UserNonAdminCannotEscalateToAdminException}.
+     */
+    public UserNonAdminCannotEscalateToAdminException() {
+        super("Non-admins cannot modify themselves to be an admin!");
+    }
+
+}

--- a/src/main/java/org/hmhb/exception/user/UserNotAllowedToAccessOtherProfileException.java
+++ b/src/main/java/org/hmhb/exception/user/UserNotAllowedToAccessOtherProfileException.java
@@ -1,0 +1,18 @@
+package org.hmhb.exception.user;
+
+import org.hmhb.exception.NotAuthorizedException;
+
+/**
+ * An exception to indicate that a non-admin tried to view / change someone
+ * else's profile.
+ */
+public class UserNotAllowedToAccessOtherProfileException extends NotAuthorizedException {
+
+    /**
+     * Constructs a {@link UserNotAllowedToAccessOtherProfileException}.
+     */
+    public UserNotAllowedToAccessOtherProfileException() {
+        super("Non-admins aren't allowed to access others' profiles!");
+    }
+
+}

--- a/src/main/java/org/hmhb/exception/user/UserNotFoundException.java
+++ b/src/main/java/org/hmhb/exception/user/UserNotFoundException.java
@@ -10,10 +10,10 @@ public class UserNotFoundException extends NotFoundException {
     /**
      * Constructs a {@link UserNotFoundException}.
      *
-     * @param email the {@link org.hmhb.user.HmhbUser}'s email that wasn't found
+     * @param id the {@link org.hmhb.user.HmhbUser}'s database ID that wasn't found
      */
-    public UserNotFoundException(String email) {
-        super("User wasn't found: email=" + email);
+    public UserNotFoundException(Long id) {
+        super("User wasn't found: id=" + id);
     }
 
 }

--- a/src/main/java/org/hmhb/exception/user/UserSuperAdminCannotBeModifiedByOthers.java
+++ b/src/main/java/org/hmhb/exception/user/UserSuperAdminCannotBeModifiedByOthers.java
@@ -1,0 +1,18 @@
+package org.hmhb.exception.user;
+
+import org.hmhb.exception.NotAuthorizedException;
+
+/**
+ * An exception to indicate that someone tried to update someone else's
+ * super-admin profile.
+ */
+public class UserSuperAdminCannotBeModifiedByOthers extends NotAuthorizedException {
+
+    /**
+     * Constructs a {@link UserSuperAdminCannotBeModifiedByOthers}.
+     */
+    public UserSuperAdminCannotBeModifiedByOthers() {
+        super("Super admins can only be modified by themselves!");
+    }
+
+}

--- a/src/main/java/org/hmhb/user/DefaultUserService.java
+++ b/src/main/java/org/hmhb/user/DefaultUserService.java
@@ -2,8 +2,19 @@ package org.hmhb.user;
 
 import javax.annotation.Nonnull;
 
+import java.util.List;
+
 import com.codahale.metrics.annotation.Timed;
 import com.google.api.services.plus.model.Person;
+import org.apache.commons.lang3.StringUtils;
+import org.hmhb.audit.AuditHelper;
+import org.hmhb.authorization.AuthorizationService;
+import org.hmhb.exception.user.UserCannotDeleteSuperAdminException;
+import org.hmhb.exception.user.UserEmailRequiredException;
+import org.hmhb.exception.user.UserNonAdminCannotEscalateToAdminException;
+import org.hmhb.exception.user.UserNotAllowedToAccessOtherProfileException;
+import org.hmhb.exception.user.UserNotFoundException;
+import org.hmhb.exception.user.UserSuperAdminCannotBeModifiedByOthers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,17 +30,27 @@ public class DefaultUserService implements UserService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultUserService.class);
 
+    private final AuditHelper auditHelper;
+    private final AuthorizationService authorizationService;
     private final UserDao dao;
 
     /**
      * An injectable constructor.
      *
+     * @param auditHelper the {@link AuditHelper} to get useful audit info
+     * @param authorizationService the {@link AuthorizationService} to verify
+     *                             that the logged in user is allowed to do
+     *                             the operations attempted
      * @param dao the {@link UserDao} to save and retrieve {@link HmhbUser}s
      */
     @Autowired
     public DefaultUserService(
+            @Nonnull AuditHelper auditHelper,
+            @Nonnull AuthorizationService authorizationService,
             @Nonnull UserDao dao
     ) {
+        this.auditHelper = requireNonNull(auditHelper, "auditHelper cannot be null");
+        this.authorizationService = requireNonNull(authorizationService, "authorizationService cannot be null");
         this.dao = requireNonNull(dao, "dao cannot be null");
     }
 
@@ -43,12 +64,20 @@ public class DefaultUserService implements UserService {
         requireNonNull(email, "email cannot be null");
         requireNonNull(profile, "profile cannot be null");
 
+        /* This method isn't exposed and is only used by the system, so there isn't a need to check authorization. */
+
         HmhbUser user = dao.findByEmailIgnoreCase(email);
 
         if (user == null) {
             user = new HmhbUser();
+            user.setSuperAdmin(false);
             user.setAdmin(false);
             user.setEmail(email);
+            user.setCreatedBy("system-generated");
+            user.setCreatedOn(auditHelper.getCurrentTime());
+        } else {
+            user.setUpdatedBy("system-updated-from-google-login");
+            user.setUpdatedOn(auditHelper.getCurrentTime());
         }
 
         user.setProfileUrl(profile.getUrl());
@@ -64,5 +93,140 @@ public class DefaultUserService implements UserService {
 
         return dao.save(user);
     }
+
+    /**
+     * Checks whether the logged in user is an admin, or the logged in user is
+     * trying to view / modify their own profile.
+     *
+     * @param userId the database ID of the {@link HmhbUser} that is going to
+     *               be viewed / modified
+     * @return true if the logged in user is allowed to view / change the
+     * profile, false otherwise
+     */
+    private boolean isAllowed(Long userId) {
+        HmhbUser currentUser = authorizationService.getLoggedInUser();
+
+        /* Admins can see/edit all profiles and users can see/edit their own profile. */
+        return authorizationService.isAdmin()
+                || (currentUser != null && currentUser.getId().equals(userId));
+    }
+
+    @Timed
+    @Override
+    public HmhbUser getById(
+            @Nonnull Long id
+    ) {
+        LOGGER.debug("getById called: id={}", id);
+        requireNonNull(id, "id cannot be null");
+
+        if (!isAllowed(id)) {
+            throw new UserNotAllowedToAccessOtherProfileException();
+        }
+
+        HmhbUser result = dao.findOne(id);
+
+        if (result == null) {
+            throw new UserNotFoundException(id);
+        }
+
+        return result;
+    }
+
+    @Timed
+    @Override
+    public List<HmhbUser> getAll() {
+        LOGGER.debug("getAll called");
+
+        if (!authorizationService.isAdmin()) {
+            throw new UserNotAllowedToAccessOtherProfileException();
+        }
+
+        return dao.findAllByOrderByDisplayNameAscEmailAsc();
+    }
+
+    @Timed
+    @Override
+    public HmhbUser delete(
+            @Nonnull Long id
+    ) {
+        LOGGER.debug("delete called: id={}", id);
+        requireNonNull(id, "id cannot be null");
+
+        if (!isAllowed(id)) {
+            throw new UserNotAllowedToAccessOtherProfileException();
+        }
+
+        /* Verify the user exists. */
+        HmhbUser user = getById(id);
+
+        if (user.isSuperAdmin()) {
+            throw new UserCannotDeleteSuperAdminException();
+        }
+
+        dao.delete(id);
+
+        return user;
+    }
+
+    @Timed
+    @Override
+    public HmhbUser save(
+            @Nonnull HmhbUser user
+    ) {
+        LOGGER.debug("save called: user={}", user);
+        requireNonNull(user, "user cannot be null");
+
+        if (StringUtils.isBlank(user.getEmail())) {
+            throw new UserEmailRequiredException();
+        }
+
+        HmhbUser userInDb = null;
+
+        if (user.getId() != null) {
+            /* Verify it exists and user has access. */
+            userInDb = getById(user.getId());
+        }
+
+        if (userInDb == null) {
+
+            if (!authorizationService.isAdmin()) {
+                throw new UserNotAllowedToAccessOtherProfileException();
+            }
+
+            user.setCreatedBy(auditHelper.getCurrentUserEmail());
+            user.setCreatedOn(auditHelper.getCurrentTime());
+            user.setUpdatedBy(null);
+            user.setUpdatedOn(null);
+
+            /* I'm not letting anyone change super admin yet. */
+            user.setSuperAdmin(false);
+        } else {
+
+            if (!authorizationService.isAdmin() && user.isAdmin()) {
+                throw new UserNonAdminCannotEscalateToAdminException();
+            }
+
+            if (userInDb.isSuperAdmin()) {
+
+                if (!authorizationService.getLoggedInUser().getId().equals(userInDb.getId())) {
+                    throw new UserSuperAdminCannotBeModifiedByOthers();
+                }
+
+                /* super-admin implies admin */
+                user.setAdmin(true);
+            }
+
+            user.setCreatedBy(userInDb.getCreatedBy());
+            user.setCreatedOn(userInDb.getCreatedOn());
+            user.setUpdatedBy(auditHelper.getCurrentUserEmail());
+            user.setUpdatedOn(auditHelper.getCurrentTime());
+
+            /* I'm not letting anyone change super admin yet. */
+            user.setSuperAdmin(userInDb.isSuperAdmin());
+        }
+
+        return dao.save(user);
+    }
+
 
 }

--- a/src/main/java/org/hmhb/user/HmhbUser.java
+++ b/src/main/java/org/hmhb/user/HmhbUser.java
@@ -6,6 +6,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
+import java.util.Date;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -23,7 +25,8 @@ public class HmhbUser {
     @NotNull
     private String email;
 
-    @NotNull
+    private boolean superAdmin;
+
     private boolean admin;
 
     private String displayName;
@@ -41,6 +44,16 @@ public class HmhbUser {
     private String suffix;
 
     private String profileUrl;
+
+    @NotNull
+    private Date createdOn;
+
+    @NotNull
+    private String createdBy;
+
+    private Date updatedOn;
+
+    private String updatedBy;
 
     @Override
     public boolean equals(Object o) {
@@ -71,6 +84,14 @@ public class HmhbUser {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public boolean isSuperAdmin() {
+        return superAdmin;
+    }
+
+    public void setSuperAdmin(boolean superAdmin) {
+        this.superAdmin = superAdmin;
     }
 
     public boolean isAdmin() {
@@ -143,6 +164,38 @@ public class HmhbUser {
 
     public void setProfileUrl(String profileUrl) {
         this.profileUrl = profileUrl;
+    }
+
+    public Date getCreatedOn() {
+        return createdOn;
+    }
+
+    public void setCreatedOn(Date createdOn) {
+        this.createdOn = createdOn;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public Date getUpdatedOn() {
+        return updatedOn;
+    }
+
+    public void setUpdatedOn(Date updatedOn) {
+        this.updatedOn = updatedOn;
+    }
+
+    public String getUpdatedBy() {
+        return updatedBy;
+    }
+
+    public void setUpdatedBy(String updatedBy) {
+        this.updatedBy = updatedBy;
     }
 
 }

--- a/src/main/java/org/hmhb/user/UserController.java
+++ b/src/main/java/org/hmhb/user/UserController.java
@@ -1,11 +1,11 @@
-package org.hmhb.program;
+package org.hmhb.user;
 
 import javax.annotation.Nonnull;
 
 import java.util.List;
 
 import com.codahale.metrics.annotation.Timed;
-import org.hmhb.exception.program.ProgramIdMismatchException;
+import org.hmhb.exception.user.UserIdMismatchException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,58 +19,58 @@ import org.springframework.web.bind.annotation.RestController;
 import static java.util.Objects.requireNonNull;
 
 /**
- * REST endpoint for {@link Program} objects.
+ * REST endpoint for {@link HmhbUser} objects.
  */
 @RestController
-public class ProgramController {
+public class UserController {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ProgramController.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserController.class);
 
-    private final ProgramService service;
+    private final UserService service;
 
     /**
      * An injectable constructor.
      *
-     * @param service the {@link ProgramService} for saving, deleting, and
-     *                retrieving {@link Program}
+     * @param service the {@link UserService} for saving, deleting, and
+     *                retrieving {@link HmhbUser}s
      */
     @Autowired
-    public ProgramController(
-            @Nonnull ProgramService service
+    public UserController(
+            @Nonnull UserService service
     ) {
         LOGGER.debug("constructed");
         this.service = requireNonNull(service, "service cannot be null");
     }
 
     /**
-     * Retrieves all {@link Program}s in the system.
+     * Retrieves all {@link HmhbUser}s in the system.
      *
-     * @return all {@link Program}s
+     * @return all {@link HmhbUser}s
      */
     @Timed
     @RequestMapping(
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_VALUE,
-            path = "/api/programs"
+            path = "/api/users"
     )
-    public List<Program> getAll() {
+    public List<HmhbUser> getAll() {
         LOGGER.debug("getAll called");
         return service.getAll();
     }
 
     /**
-     * Retrieves a {@link Program} by its database ID.
+     * Retrieves a {@link HmhbUser} by its database ID.
      *
      * @param id the database ID
-     * @return the {@link Program}
+     * @return the {@link HmhbUser}
      */
     @Timed
     @RequestMapping(
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_VALUE,
-            path = "/api/programs/{id}"
+            path = "/api/users/{id}"
     )
-    public Program getById(
+    public HmhbUser getById(
             @PathVariable long id
     ) {
         LOGGER.debug("getById called: id={}", id);
@@ -78,65 +78,65 @@ public class ProgramController {
     }
 
     /**
-     * Creates a new {@link Program}.
+     * Creates a new {@link HmhbUser}.
      *
-     * @param program the new {@link Program} to create
-     * @return the newly created {@link Program}
+     * @param user the new {@link HmhbUser} to create
+     * @return the newly created {@link HmhbUser}
      */
     @Timed
     @RequestMapping(
             method = RequestMethod.POST,
             produces = MediaType.APPLICATION_JSON_VALUE,
             consumes = MediaType.APPLICATION_JSON_VALUE,
-            path = "/api/programs"
+            path = "/api/users"
     )
-    public Program create(
-            @RequestBody Program program
+    public HmhbUser create(
+            @RequestBody HmhbUser user
     ) {
-        LOGGER.debug("create called: program={}", program);
-        return service.save(program);
+        LOGGER.debug("create called: user={}", user);
+        return service.save(user);
     }
 
     /**
-     * Updates an existing {@link Program}.
+     * Updates an existing {@link HmhbUser}.
      *
-     * @param id the database ID of the {@link Program} to update
-     * @param program the {@link Program} to update to
-     * @return the updated {@link Program}
+     * @param id the database ID of the {@link HmhbUser} to update
+     * @param user the {@link HmhbUser} to update to
+     * @return the updated {@link HmhbUser}
      */
     @Timed
     @RequestMapping(
             method = RequestMethod.POST,
             produces = MediaType.APPLICATION_JSON_VALUE,
             consumes = MediaType.APPLICATION_JSON_VALUE,
-            path = "/api/programs/{id}"
+            path = "/api/users/{id}"
     )
-    public Program update(
+    public HmhbUser update(
             @PathVariable long id,
-            @RequestBody Program program
+            @RequestBody HmhbUser user
     ) {
-        LOGGER.debug("update called: id={}, program={}", id, program);
+        LOGGER.debug("update called: id={}, user={}", id, user);
 
-        if (!Long.valueOf(id).equals(program.getId())) {
-            throw new ProgramIdMismatchException(id, program.getId());
+        if (!Long.valueOf(id).equals(user.getId())) {
+            throw new UserIdMismatchException(id, user.getId());
         }
 
-        return service.save(program);
+        return service.save(user);
     }
 
     /**
-     * Deletes a {@link Program}.
+     * Deletes a {@link HmhbUser}.
      *
-     * @param id the database ID of the {@link Program} to delete
-     * @return the deleted {@link Program}
+     * @param id the database ID of the {@link HmhbUser} to delete
+     * @return the deleted {@link HmhbUser}
      */
     @Timed
     @RequestMapping(
             method = RequestMethod.DELETE,
             produces = MediaType.APPLICATION_JSON_VALUE,
-            path = "/api/programs/{id}"
+            path = "/api/users/{id}"
     )
-    public Program delete(
+    public HmhbUser delete(
             @PathVariable long id
     ) {
         LOGGER.debug("delete called: id={}", id);

--- a/src/main/java/org/hmhb/user/UserDao.java
+++ b/src/main/java/org/hmhb/user/UserDao.java
@@ -1,5 +1,7 @@
 package org.hmhb.user;
 
+import java.util.List;
+
 import org.springframework.data.repository.CrudRepository;
 
 /**
@@ -16,5 +18,13 @@ public interface UserDao extends CrudRepository<HmhbUser, Long> {
      * @return the {@link HmhbUser}s
      */
     HmhbUser findByEmailIgnoreCase(String email);
+
+    /**
+     * Returns all {@link HmhbUser}s ordered ascending by their display names,
+     * then emails.
+     *
+     * @return all {@link HmhbUser}s
+     */
+    List<HmhbUser> findAllByOrderByDisplayNameAscEmailAsc();
 
 }

--- a/src/main/java/org/hmhb/user/UserService.java
+++ b/src/main/java/org/hmhb/user/UserService.java
@@ -2,6 +2,8 @@ package org.hmhb.user;
 
 import javax.annotation.Nonnull;
 
+import java.util.List;
+
 import com.google.api.services.plus.model.Person;
 
 /**
@@ -20,6 +22,43 @@ public interface UserService {
     HmhbUser saveWithGoogleData(
             @Nonnull String email,
             @Nonnull Person profile
+    );
+
+    /**
+     * Retrieves a {@link HmhbUser} by its database ID.
+     *
+     * @param id the database ID
+     * @return the {@link HmhbUser}
+     */
+    HmhbUser getById(
+            @Nonnull Long id
+    );
+
+    /**
+     * Retrieves all {@link HmhbUser}s in the system.
+     *
+     * @return all {@link HmhbUser}s
+     */
+    List<HmhbUser> getAll();
+
+    /**
+     * Deletes a {@link HmhbUser} by its database ID.
+     *
+     * @param id the database ID
+     * @return the deleted {@link HmhbUser}
+     */
+    HmhbUser delete(
+            @Nonnull Long id
+    );
+
+    /**
+     * Saves a {@link HmhbUser} (create or update).
+     *
+     * @param user the {@link HmhbUser} to create or update
+     * @return the saved {@link HmhbUser}
+     */
+    HmhbUser save(
+            @Nonnull HmhbUser user
     );
 
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -5,42 +5,64 @@
  **********************************/
 INSERT INTO hmhb_user (
     email,
-    admin
+    admin,
+    super_admin,
+    created_on,
+    created_by
 ) VALUES (
     'john.ryan.bard@gmail.com',
-    TRUE
+    TRUE,
+    TRUE,
+    CURRENT_TIMESTAMP,
+    'initial data script'
 );
 
 INSERT INTO hmhb_user (
     email,
-    admin
+    admin,
+    created_on,
+    created_by
 ) VALUES (
     'mckoon@gmail.com',
-    TRUE
+    TRUE,
+    CURRENT_TIMESTAMP,
+    'initial data script'
 );
 
 INSERT INTO hmhb_user (
     email,
-    admin
+    admin,
+    created_on,
+    created_by
 ) VALUES (
     'jlgett@gmail.com',
-    TRUE
+    TRUE,
+    CURRENT_TIMESTAMP,
+    'initial data script'
 );
 
 INSERT INTO hmhb_user (
     email,
-    admin
+    admin,
+    created_on,
+    created_by
 ) VALUES (
     'jslide07@gmail.com',
-    TRUE
+    TRUE,
+    CURRENT_TIMESTAMP,
+    'initial data script'
 );
 
 INSERT INTO hmhb_user (
     email,
-    admin
+    admin,
+    created_on,
+    created_by
 ) VALUES (
     'contactkaranpratap@gmail.com',
-    TRUE
+    TRUE,
+    CURRENT_TIMESTAMP,
+    'initial data script'
 );
 /**********************************
  * End Users.

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -10,8 +10,9 @@ DROP TABLE IF EXISTS hmhb_user;
 
 CREATE TABLE hmhb_user (
     id BIGSERIAL PRIMARY KEY,
-    email TEXT NOT NULL UNIQUE,
-    admin BOOLEAN NOT NULL,
+    email TEXT NOT NULL,
+    super_admin BOOLEAN NOT NULL DEFAULT FALSE,
+    admin BOOLEAN NOT NULL DEFAULT FALSE,
     display_name TEXT,
     image_url TEXT,
     first_name TEXT,
@@ -19,8 +20,17 @@ CREATE TABLE hmhb_user (
     middle_name TEXT,
     prefix TEXT,
     suffix TEXT,
-    profile_url TEXT
+    profile_url TEXT,
+    created_on DATE NOT NULL,
+    created_by TEXT NOT NULL,
+    updated_on DATE,
+    updated_by TEXT
 );
+
+/*
+ * Create the unique index to make the unique constraint on emails case insensitive.
+ */
+CREATE UNIQUE INDEX hmhb_user_lower_email_index ON hmhb_user(LOWER(email));
 
 CREATE TABLE organization (
     id BIGSERIAL PRIMARY KEY,
@@ -43,7 +53,7 @@ CREATE TABLE county (
     inner_boundary1 TEXT,
     outer_boundary2 TEXT,
     outer_boundary3 TEXT,
-    UNIQUE (name, state)
+    UNIQUE(name, state)
 );
 
 CREATE TABLE program_area (
@@ -73,7 +83,7 @@ CREATE TABLE program (
     created_by TEXT NOT NULL,
     updated_on DATE,
     updated_by TEXT,
-    UNIQUE (name, organization_id)
+    UNIQUE(name, organization_id)
 );
 
 CREATE TABLE program_county (

--- a/src/test/java/org/hmhb/user/DefaultUserServiceTest.java
+++ b/src/test/java/org/hmhb/user/DefaultUserServiceTest.java
@@ -1,6 +1,18 @@
 package org.hmhb.user;
 
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
 import com.google.api.services.plus.model.Person;
+import org.hmhb.audit.AuditHelper;
+import org.hmhb.authorization.AuthorizationService;
+import org.hmhb.exception.user.UserCannotDeleteSuperAdminException;
+import org.hmhb.exception.user.UserEmailRequiredException;
+import org.hmhb.exception.user.UserNonAdminCannotEscalateToAdminException;
+import org.hmhb.exception.user.UserNotAllowedToAccessOtherProfileException;
+import org.hmhb.exception.user.UserNotFoundException;
+import org.hmhb.exception.user.UserSuperAdminCannotBeModifiedByOthers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -13,20 +25,34 @@ import static org.mockito.Mockito.*;
 public class DefaultUserServiceTest {
 
     private static final Long USER_ID = 123L;
+    private static final Long OTHER_USER_ID = 456L;
     private static final String DISPLAY_NAME = "John Doe";
     private static final String EMAIL = "john.doe@mailinator.com";
+    private static final String OTHER_EMAIL = "other.person@mailinator.com";
     private static final String FIRST_NAME = "John";
     private static final String LAST_NAME = "Doe";
     private static final String IMAGE_URL = "https://lh3.googleusercontent.com/-XdUIq/AAAI/AAAA/42cv5M/photo.jpg?sz=50";
     private static final String PROFILE_URL = "something";
 
+    private static final Date BEFORE = new Date(1234567890L);
+    private static final Date NOW = new Date(9876543210L);
+
+    private AuditHelper auditHelper;
+    private AuthorizationService authorizationService;
     private UserDao dao;
     private DefaultUserService toTest;
 
     @Before
     public void setUp() throws Exception {
+        auditHelper = mock(AuditHelper.class);
+        authorizationService = mock(AuthorizationService.class);
         dao = mock(UserDao.class);
-        toTest = new DefaultUserService(dao);
+
+        toTest = new DefaultUserService(
+                auditHelper,
+                authorizationService,
+                dao
+        );
     }
 
     @Test
@@ -40,6 +66,8 @@ public class DefaultUserServiceTest {
         userInDb.setLastName(LAST_NAME + "-old");
         userInDb.setImageUrl(IMAGE_URL + "-old");
         userInDb.setProfileUrl(PROFILE_URL + "-old");
+        userInDb.setCreatedBy("system-generated");
+        userInDb.setCreatedOn(BEFORE);
 
         HmhbUser expected = new HmhbUser();
         expected.setId(USER_ID);
@@ -50,6 +78,10 @@ public class DefaultUserServiceTest {
         expected.setLastName(LAST_NAME);
         expected.setImageUrl(IMAGE_URL);
         expected.setProfileUrl(PROFILE_URL);
+        expected.setCreatedBy("system-generated");
+        expected.setCreatedOn(BEFORE);
+        expected.setUpdatedBy("system-updated-from-google-login");
+        expected.setUpdatedOn(NOW);
 
         Person.Image image = new Person.Image();
         image.setUrl(IMAGE_URL);
@@ -65,6 +97,7 @@ public class DefaultUserServiceTest {
         gPlusProfile.setName(name);
 
         /* Train the mocks. */
+        when(auditHelper.getCurrentTime()).thenReturn(NOW);
         when(dao.findByEmailIgnoreCase(EMAIL)).thenReturn(userInDb);
         when(dao.save(expected)).thenReturn(expected);
 
@@ -85,6 +118,8 @@ public class DefaultUserServiceTest {
         expected.setLastName(LAST_NAME);
         expected.setImageUrl(IMAGE_URL);
         expected.setProfileUrl(PROFILE_URL);
+        expected.setCreatedBy("system-generated");
+        expected.setCreatedOn(NOW);
 
         Person.Image image = new Person.Image();
         image.setUrl(IMAGE_URL);
@@ -100,6 +135,7 @@ public class DefaultUserServiceTest {
         gPlusProfile.setName(name);
 
         /* Train the mocks. */
+        when(auditHelper.getCurrentTime()).thenReturn(NOW);
         when(dao.findByEmailIgnoreCase(EMAIL)).thenReturn(null);
         when(dao.save(expected)).thenReturn(expected);
 
@@ -108,6 +144,676 @@ public class DefaultUserServiceTest {
 
         /* Verify the results. */
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetById_Admin_FoundUser() throws Exception {
+
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(OTHER_USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(true);
+        loggedInUser.setEmail(OTHER_EMAIL);
+
+        HmhbUser expected = new HmhbUser();
+        expected.setId(USER_ID);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+        when(dao.findOne(USER_ID)).thenReturn(expected);
+
+        /* Make the call. */
+        HmhbUser actual = toTest.getById(USER_ID);
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+    @Test(expected = UserNotFoundException.class)
+    public void testGetById_Admin_UserNotFound() throws Exception {
+
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(OTHER_USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(true);
+        loggedInUser.setEmail(OTHER_EMAIL);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+        when(dao.findOne(USER_ID)).thenReturn(null);
+
+        /* Make the call. */
+        toTest.getById(USER_ID);
+    }
+
+    @Test(expected = UserNotAllowedToAccessOtherProfileException.class)
+    public void testGetById_NotLoggedIn() throws Exception {
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(false);
+        when(authorizationService.getLoggedInUser()).thenReturn(null);
+
+        /* Make the call. */
+        toTest.getById(USER_ID);
+    }
+
+    @Test(expected = UserNotAllowedToAccessOtherProfileException.class)
+    public void testGetById_NonAdmin_AccessingOtherProfile() {
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(OTHER_USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(false);
+        loggedInUser.setEmail(OTHER_EMAIL);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(false);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+
+        /* Make the call. */
+        toTest.getById(USER_ID);
+    }
+
+    @Test
+    public void testGetById_NonAdmin_AccessingOwnProfile() {
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(false);
+        loggedInUser.setEmail(EMAIL);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(false);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+        when(dao.findOne(USER_ID)).thenReturn(loggedInUser);
+
+        /* Make the call. */
+        HmhbUser actual = toTest.getById(USER_ID);
+
+        /* Verify the results. */
+        assertEquals(loggedInUser, actual);
+    }
+
+    @Test
+    public void testGetAll_Admin() throws Exception {
+
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(OTHER_USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(true);
+        loggedInUser.setEmail(OTHER_EMAIL);
+
+        HmhbUser expectedUser = new HmhbUser();
+        expectedUser.setId(USER_ID);
+
+        List<HmhbUser> expected = Collections.singletonList(expectedUser);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+        when(dao.findAllByOrderByDisplayNameAscEmailAsc()).thenReturn(expected);
+
+        /* Make the call. */
+        List<HmhbUser> actual = toTest.getAll();
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+    @Test(expected = UserNotAllowedToAccessOtherProfileException.class)
+    public void testGetAll_NotLoggedIn() throws Exception {
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(false);
+        when(authorizationService.getLoggedInUser()).thenReturn(null);
+
+        /* Make the call. */
+        toTest.getAll();
+    }
+
+    @Test(expected = UserNotAllowedToAccessOtherProfileException.class)
+    public void testGetAll_NonAdmin_AccessingOtherProfile() {
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(OTHER_USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(false);
+        loggedInUser.setEmail(OTHER_EMAIL);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(false);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+
+        /* Make the call. */
+        toTest.getAll();
+    }
+
+    @Test
+    public void testSave_SuperAdmin_UpdatesTheirProfile() throws Exception {
+        HmhbUser input = new HmhbUser();
+        input.setId(USER_ID);
+        input.setSuperAdmin(false); /* this should be ignored */
+        input.setAdmin(false); /* this should be ignored */
+        input.setEmail(EMAIL);
+        /* Try setting audit info; the system should ignore it. */
+        input.setCreatedBy("try to change this");
+        input.setCreatedOn(new Date(-1));
+        input.setUpdatedBy("trying to set this");
+        input.setUpdatedOn(new Date(-2));
+
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(USER_ID);
+        loggedInUser.setSuperAdmin(true);
+        loggedInUser.setAdmin(true);
+        loggedInUser.setEmail(EMAIL);
+
+        HmhbUser userInDb = new HmhbUser();
+        userInDb.setId(USER_ID);
+        userInDb.setSuperAdmin(true);
+        userInDb.setAdmin(true);
+        userInDb.setEmail(EMAIL);
+        userInDb.setCreatedBy("system-generated");
+        userInDb.setCreatedOn(BEFORE);
+
+        HmhbUser expected = new HmhbUser();
+        expected.setId(USER_ID);
+        expected.setSuperAdmin(true); /* super admin cannot be changed */
+        expected.setAdmin(true); /* super admin implies admin */
+        expected.setEmail(EMAIL);
+        expected.setCreatedBy("system-generated");
+        expected.setCreatedOn(BEFORE);
+        expected.setUpdatedBy(OTHER_EMAIL);
+        expected.setUpdatedOn(NOW);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+        when(dao.findOne(USER_ID)).thenReturn(userInDb);
+        when(auditHelper.getCurrentUserEmail()).thenReturn(OTHER_EMAIL);
+        when(auditHelper.getCurrentTime()).thenReturn(NOW);
+        when(dao.save(expected)).thenReturn(expected);
+
+        /* Make the call. */
+        HmhbUser actual = toTest.save(input);
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+    @Test(expected = UserSuperAdminCannotBeModifiedByOthers.class)
+    public void testSave_Admin_TriesToUpdateSuperAdmin() throws Exception {
+        HmhbUser input = new HmhbUser();
+        input.setId(USER_ID);
+        input.setSuperAdmin(true);
+        input.setAdmin(true);
+        input.setEmail(EMAIL);
+        /* Try setting audit info; the system should ignore it. */
+        input.setCreatedBy("try to change this");
+        input.setCreatedOn(new Date(-1));
+        input.setUpdatedBy("trying to set this");
+        input.setUpdatedOn(new Date(-2));
+
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(OTHER_USER_ID);
+        loggedInUser.setSuperAdmin(true);
+        loggedInUser.setAdmin(true);
+        loggedInUser.setEmail(OTHER_EMAIL);
+
+        HmhbUser userInDb = new HmhbUser();
+        userInDb.setId(USER_ID);
+        userInDb.setSuperAdmin(true);
+        userInDb.setAdmin(true);
+        userInDb.setEmail(EMAIL);
+        userInDb.setCreatedBy("system-generated");
+        userInDb.setCreatedOn(BEFORE);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+        when(dao.findOne(USER_ID)).thenReturn(userInDb);
+
+        /* Make the call. */
+        toTest.save(input);
+    }
+
+    @Test
+    public void testSave_Admin_UpdateExistingUser() throws Exception {
+        HmhbUser input = new HmhbUser();
+        input.setId(USER_ID);
+        input.setAdmin(true);
+        input.setEmail(EMAIL);
+        /* Try setting audit info; the system should ignore it. */
+        input.setCreatedBy("try to change this");
+        input.setCreatedOn(new Date(-1));
+        input.setUpdatedBy("trying to set this");
+        input.setUpdatedOn(new Date(-2));
+
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(OTHER_USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(true);
+        loggedInUser.setEmail(OTHER_EMAIL);
+
+        HmhbUser userInDb = new HmhbUser();
+        userInDb.setId(USER_ID);
+        userInDb.setAdmin(false);
+        userInDb.setEmail(EMAIL);
+        userInDb.setCreatedBy("system-generated");
+        userInDb.setCreatedOn(BEFORE);
+
+        HmhbUser expected = new HmhbUser();
+        expected.setId(USER_ID);
+        expected.setAdmin(true);
+        expected.setEmail(EMAIL);
+        expected.setCreatedBy("system-generated");
+        expected.setCreatedOn(BEFORE);
+        expected.setUpdatedBy(OTHER_EMAIL);
+        expected.setUpdatedOn(NOW);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+        when(dao.findOne(USER_ID)).thenReturn(userInDb);
+        when(auditHelper.getCurrentUserEmail()).thenReturn(OTHER_EMAIL);
+        when(auditHelper.getCurrentTime()).thenReturn(NOW);
+        when(dao.save(expected)).thenReturn(expected);
+
+        /* Make the call. */
+        HmhbUser actual = toTest.save(input);
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testSave_Admin_CreateNewUser() throws Exception {
+        HmhbUser input = new HmhbUser();
+        input.setId(null);
+        input.setAdmin(true);
+        input.setEmail(EMAIL);
+        /* Try setting audit info; the system should ignore it. */
+        input.setCreatedBy("try to change this");
+        input.setCreatedOn(new Date(-1));
+        input.setUpdatedBy("trying to set this");
+        input.setUpdatedOn(new Date(-2));
+
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(OTHER_USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(true);
+        loggedInUser.setEmail(OTHER_EMAIL);
+
+        HmhbUser expected = new HmhbUser();
+        expected.setAdmin(true);
+        expected.setEmail(EMAIL);
+        expected.setCreatedBy(OTHER_EMAIL);
+        expected.setCreatedOn(NOW);
+        expected.setUpdatedBy(null);
+        expected.setUpdatedOn(null);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+        when(auditHelper.getCurrentUserEmail()).thenReturn(OTHER_EMAIL);
+        when(auditHelper.getCurrentTime()).thenReturn(NOW);
+        when(dao.save(expected)).thenReturn(expected);
+
+        /* Make the call. */
+        HmhbUser actual = toTest.save(input);
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+    @Test(expected = UserEmailRequiredException.class)
+    public void testSave_Admin_CreateNewUser_NullEmail() throws Exception {
+        HmhbUser input = new HmhbUser();
+        input.setId(null);
+        input.setAdmin(true);
+        input.setEmail(null);
+
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(OTHER_USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(true);
+        loggedInUser.setEmail(OTHER_EMAIL);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+
+        /* Make the call. */
+        toTest.save(input);
+    }
+
+    @Test(expected = UserEmailRequiredException.class)
+    public void testSave_Admin_CreateNewUser_EmptyEmail() throws Exception {
+        HmhbUser input = new HmhbUser();
+        input.setId(null);
+        input.setAdmin(true);
+        input.setEmail("");
+
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(OTHER_USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(true);
+        loggedInUser.setEmail(OTHER_EMAIL);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+
+        /* Make the call. */
+        toTest.save(input);
+    }
+
+    @Test(expected = UserEmailRequiredException.class)
+    public void testSave_Admin_CreateNewUser_WhitespaceEmail() throws Exception {
+        HmhbUser input = new HmhbUser();
+        input.setId(null);
+        input.setAdmin(true);
+        input.setEmail("   ");
+
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(OTHER_USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(true);
+        loggedInUser.setEmail(OTHER_EMAIL);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+
+        /* Make the call. */
+        toTest.save(input);
+    }
+
+    @Test(expected = UserNotAllowedToAccessOtherProfileException.class)
+    public void testSave_NotLoggedIn() throws Exception {
+        HmhbUser input = new HmhbUser();
+        input.setId(null);
+        input.setEmail(EMAIL);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(false);
+        when(authorizationService.getLoggedInUser()).thenReturn(null);
+
+        /* Make the call. */
+        toTest.save(input);
+    }
+
+    @Test(expected = UserNotAllowedToAccessOtherProfileException.class)
+    public void testSave_NonAdmin_ModifyingOtherProfile() {
+        HmhbUser input = new HmhbUser();
+        input.setId(USER_ID);
+        input.setEmail(EMAIL);
+
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(OTHER_USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(false);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(false);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+
+        /* Make the call. */
+        toTest.save(input);
+    }
+
+    @Test(expected = UserNotAllowedToAccessOtherProfileException.class)
+    public void testSave_NonAdmin_CreatingNewProfile() {
+        HmhbUser input = new HmhbUser();
+        input.setId(null);
+        input.setEmail(EMAIL);
+
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(OTHER_USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(false);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(false);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+
+        /* Make the call. */
+        toTest.save(input);
+    }
+
+    @Test
+    public void testSave_NonAdmin_ModifyingOwnProfile() {
+        HmhbUser input = new HmhbUser();
+        input.setId(USER_ID);
+        input.setEmail(EMAIL);
+
+        HmhbUser userInDb = new HmhbUser();
+        userInDb.setId(USER_ID);
+        userInDb.setAdmin(false);
+        userInDb.setEmail(EMAIL);
+        userInDb.setCreatedBy("system-generated");
+        userInDb.setCreatedOn(BEFORE);
+
+        HmhbUser expected = new HmhbUser();
+        expected.setId(USER_ID);
+        expected.setAdmin(false);
+        expected.setEmail(EMAIL);
+        expected.setCreatedBy("system-generated");
+        expected.setCreatedOn(BEFORE);
+        expected.setUpdatedBy(EMAIL);
+        expected.setUpdatedOn(NOW);
+
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(false);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(false);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+        when(dao.findOne(USER_ID)).thenReturn(userInDb);
+        when(auditHelper.getCurrentUserEmail()).thenReturn(EMAIL);
+        when(auditHelper.getCurrentTime()).thenReturn(NOW);
+        when(dao.save(expected)).thenReturn(expected);
+
+        /* Make the call. */
+        HmhbUser actual = toTest.save(input);
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+    @Test(expected = UserNonAdminCannotEscalateToAdminException.class)
+    public void testSave_NonAdmin_ModifyingOwnProfile_PrivilegeEscalation() {
+        HmhbUser input = new HmhbUser();
+        input.setId(USER_ID);
+        input.setAdmin(true); /* non-admin is trying to escalate privileges to admin */
+        input.setEmail(EMAIL);
+
+        HmhbUser userInDb = new HmhbUser();
+        userInDb.setId(USER_ID);
+        userInDb.setAdmin(false);
+        userInDb.setEmail(EMAIL);
+        userInDb.setCreatedBy("system-generated");
+        userInDb.setCreatedOn(BEFORE);
+
+        HmhbUser expected = new HmhbUser();
+        expected.setId(USER_ID);
+        expected.setAdmin(false);
+        expected.setEmail(EMAIL);
+        expected.setCreatedBy("system-generated");
+        expected.setCreatedOn(BEFORE);
+        expected.setUpdatedBy(EMAIL);
+        expected.setUpdatedOn(NOW);
+
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(false);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(false);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+        when(dao.findOne(USER_ID)).thenReturn(userInDb);
+
+        /* Make the call. */
+        toTest.save(input);
+    }
+
+    @Test
+    public void testSave_Admin_PrivilegeEscalation() {
+        HmhbUser input = new HmhbUser();
+        input.setId(USER_ID);
+        input.setSuperAdmin(true); /* admin is trying to escalate privileges to super-admin */
+        input.setAdmin(true);
+        input.setEmail(EMAIL);
+
+        HmhbUser userInDb = new HmhbUser();
+        userInDb.setId(USER_ID);
+        userInDb.setSuperAdmin(false);
+        userInDb.setAdmin(true);
+        userInDb.setEmail(EMAIL);
+        userInDb.setCreatedBy("system-generated");
+        userInDb.setCreatedOn(BEFORE);
+
+        HmhbUser expected = new HmhbUser();
+        expected.setId(USER_ID);
+        expected.setSuperAdmin(false); /* the system shouldn't let them change super-admin */
+        expected.setAdmin(true);
+        expected.setEmail(EMAIL);
+        expected.setCreatedBy("system-generated");
+        expected.setCreatedOn(BEFORE);
+        expected.setUpdatedBy(EMAIL);
+        expected.setUpdatedOn(NOW);
+
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(true);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+        when(dao.findOne(USER_ID)).thenReturn(userInDb);
+        when(auditHelper.getCurrentUserEmail()).thenReturn(EMAIL);
+        when(auditHelper.getCurrentTime()).thenReturn(NOW);
+        when(dao.save(expected)).thenReturn(expected);
+
+        /* Make the call. */
+        HmhbUser actual = toTest.save(input);
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testDelete_Admin_FoundUser() throws Exception {
+
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(OTHER_USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(true);
+        loggedInUser.setEmail(OTHER_EMAIL);
+
+        HmhbUser expected = new HmhbUser();
+        expected.setId(USER_ID);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+        when(dao.findOne(USER_ID)).thenReturn(expected);
+
+        /* Make the call. */
+        HmhbUser actual = toTest.delete(USER_ID);
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+        verify(dao).delete(USER_ID);
+    }
+
+    @Test(expected = UserCannotDeleteSuperAdminException.class)
+    public void testDelete_Admin_SuperAdminsCannotBeDeleted() throws Exception {
+
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(OTHER_USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(true);
+        loggedInUser.setEmail(OTHER_EMAIL);
+
+        HmhbUser userInDb = new HmhbUser();
+        userInDb.setId(USER_ID);
+        userInDb.setAdmin(true);
+        userInDb.setSuperAdmin(true);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+        when(dao.findOne(USER_ID)).thenReturn(userInDb);
+
+        /* Make the call. */
+        toTest.delete(USER_ID);
+    }
+
+    @Test(expected = UserNotFoundException.class)
+    public void testDelete_Admin_UserNotFound() throws Exception {
+
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(OTHER_USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(true);
+        loggedInUser.setEmail(OTHER_EMAIL);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+        when(dao.findOne(USER_ID)).thenReturn(null);
+
+        /* Make the call. */
+        toTest.delete(USER_ID);
+    }
+
+    @Test(expected = UserNotAllowedToAccessOtherProfileException.class)
+    public void testDelete_NotLoggedIn() throws Exception {
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(false);
+        when(authorizationService.getLoggedInUser()).thenReturn(null);
+
+        /* Make the call. */
+        toTest.delete(USER_ID);
+    }
+
+    @Test(expected = UserNotAllowedToAccessOtherProfileException.class)
+    public void testDelete_NonAdmin_AccessingOtherProfile() {
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(OTHER_USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(false);
+        loggedInUser.setEmail(OTHER_EMAIL);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(false);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+
+        /* Make the call. */
+        toTest.delete(USER_ID);
+    }
+
+    @Test
+    public void testDelete_NonAdmin_AccessingOwnProfile() {
+        HmhbUser loggedInUser = new HmhbUser();
+        loggedInUser.setId(USER_ID);
+        loggedInUser.setSuperAdmin(false);
+        loggedInUser.setAdmin(false);
+        loggedInUser.setEmail(EMAIL);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(false);
+        when(authorizationService.getLoggedInUser()).thenReturn(loggedInUser);
+        when(dao.findOne(USER_ID)).thenReturn(loggedInUser);
+
+        /* Make the call. */
+        HmhbUser actual = toTest.delete(USER_ID);
+
+        /* Verify the results. */
+        assertEquals(loggedInUser, actual);
+        verify(dao).delete(USER_ID);
     }
 
 }

--- a/src/test/java/org/hmhb/user/UserControllerTest.java
+++ b/src/test/java/org/hmhb/user/UserControllerTest.java
@@ -1,0 +1,118 @@
+package org.hmhb.user;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.hmhb.exception.user.UserIdMismatchException;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link UserController}.
+ */
+public class UserControllerTest {
+
+    private static final Long USER_ID = 123L;
+
+    private UserService service;
+    private UserController toTest;
+
+    @Before
+    public void setUp() throws Exception {
+        service = mock(UserService.class);
+        toTest = new UserController(service);
+    }
+
+    @Test
+    public void testGetAll() throws Exception {
+        List<HmhbUser> expected = Collections.singletonList(new HmhbUser());
+
+        /* Train the mocks. */
+        when(service.getAll()).thenReturn(expected);
+
+        /* Make the call. */
+        List<HmhbUser> actual = toTest.getAll();
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetById() throws Exception {
+        HmhbUser expected = new HmhbUser();
+        expected.setId(USER_ID);
+
+        /* Train the mocks. */
+        when(service.getById(USER_ID)).thenReturn(expected);
+
+        /* Make the call. */
+        HmhbUser actual = toTest.getById(USER_ID);
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCreate() throws Exception {
+        HmhbUser input = new HmhbUser();
+        input.setId(null);
+
+        HmhbUser expected = new HmhbUser();
+        expected.setId(USER_ID);
+
+        /* Train the mocks. */
+        when(service.save(input)).thenReturn(expected);
+
+        /* Make the call. */
+        HmhbUser actual = toTest.create(input);
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+   }
+
+    @Test
+    public void testUpdate() throws Exception {
+        HmhbUser input = new HmhbUser();
+        input.setId(USER_ID);
+
+        HmhbUser expected = new HmhbUser();
+        expected.setId(USER_ID);
+
+        /* Train the mocks. */
+        when(service.save(input)).thenReturn(expected);
+
+        /* Make the call. */
+        HmhbUser actual = toTest.update(USER_ID, input);
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+    @Test(expected = UserIdMismatchException.class)
+    public void testUpdate_IdMismatch() throws Exception {
+        HmhbUser input = new HmhbUser();
+        input.setId(USER_ID);
+
+        /* Make the call. */
+        toTest.update(USER_ID + 1, input);
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        HmhbUser expected = new HmhbUser();
+        expected.setId(USER_ID);
+
+        /* Train the mocks. */
+        when(service.delete(USER_ID)).thenReturn(expected);
+
+        /* Make the call. */
+        HmhbUser actual = toTest.delete(USER_ID);
+
+        /* Verify the results. */
+        assertEquals(expected, actual);
+    }
+
+}


### PR DESCRIPTION
* Adds audit columns and super_admin to hmhb_user.
* Adds user REST calls for user profile management.
* Adds user service with extensive logic to prevent mistakes and bad actors
  from wrecking the system.
* Adds user $resource to interface with the REST calls.
* Updates the unit tests.