### PR TITLE
closes #256: Add missing max length validations

### DIFF
--- a/client/src/main/webjar/organization-form/organization-form.component.js
+++ b/client/src/main/webjar/organization-form/organization-form.component.js
@@ -10,6 +10,7 @@
      * @constructor
      */
     function OrganizationFormController(
+        getConfig,
         $log
     ) {
         var organizationForm = this;
@@ -19,6 +20,8 @@
          */
         function activate() {
             $log.debug("OrganizationForm Controller loaded", organizationForm);
+
+            organizationForm.config = getConfig();
         }
 
         /* Run activate when component is loaded. */
@@ -27,6 +30,7 @@
 
     /* Inject dependencies. */
     OrganizationFormController.$inject = [
+        "getConfig",
         "$log"
     ];
 

--- a/client/src/main/webjar/organization-form/organization-form.html
+++ b/client/src/main/webjar/organization-form/organization-form.html
@@ -9,9 +9,11 @@
             </label>
             <input name="organizationName"
                    ng-model="organizationForm.organization.name"
+                   md-maxlength="organizationForm.config.organizationNameMaxLength"
                    required>
             <div ng-messages="organizationForm.orgForm.organizationName.$error">
                 <div ng-message="required">Organization name is required</div>
+                <div ng-message="md-maxlength">Organization name is too long</div>
             </div>
         </md-input-container>
 

--- a/client/src/main/webjar/organization-form/organization-form.module.js
+++ b/client/src/main/webjar/organization-form/organization-form.module.js
@@ -5,6 +5,7 @@
         "healthBam.organizationForm",
         [
             "ngMaterial",
+            "healthBam.config",
             "healthBam.templates"
         ]
     );

--- a/client/src/main/webjar/program-form-dialog/program-form-dialog.html
+++ b/client/src/main/webjar/program-form-dialog/program-form-dialog.html
@@ -79,9 +79,11 @@
                             </label>
                             <input name="programName"
                                    ng-model="programFormDialog.program.name"
+                                   md-maxlength="programFormDialog.config.programNameMaxLength"
                                    required>
                             <div ng-messages="programFormDialog.programForm.programName.$error">
                                 <div ng-message="required">Program name is required</div>
+                                <div ng-message="md-maxlength">Program name is too long</div>
                             </div>
                         </md-input-container>
 
@@ -209,9 +211,11 @@
                                 </label>
                                 <input name="otherProgramAreaExplanation"
                                        ng-model="programFormDialog.program.otherProgramAreaExplanation"
+                                       md-maxlength="programFormDialog.config.programAreaExplanationMaxLength"
                                        required>
                                 <div ng-messages="programFormDialog.programForm.otherProgramAreaExplanation.$error">
                                     <div ng-message="required">Please provide an explanation</div>
+                                    <div ng-message="md-maxlength">Explanation is too long</div>
                                 </div>
                             </md-input-container>
                         </fieldset>

--- a/config/application.properties
+++ b/config/application.properties
@@ -41,6 +41,10 @@ hmhb.program.city.maxLength = 50
 hmhb.program.goal.maxLength = 500
 hmhb.program.outcome.maxLength = 500
 
+hmhb.program.name.maxLength = 100
+hmhb.program.otherProgramArea.explanation.maxLength = 100
+hmhb.organization.name.maxLength = 100
+
 #####################################################################
 # End: Common validation settings between the client and server
 #####################################################################

--- a/src/main/java/org/hmhb/config/DefaultConfigService.java
+++ b/src/main/java/org/hmhb/config/DefaultConfigService.java
@@ -35,7 +35,10 @@ public class DefaultConfigService implements ConfigService {
                 environment.getProperty("hmhb.program.streetAddress.maxLength", Integer.class),
                 environment.getProperty("hmhb.program.city.maxLength", Integer.class),
                 environment.getProperty("hmhb.program.goal.maxLength", Integer.class),
-                environment.getProperty("hmhb.program.outcome.maxLength", Integer.class)
+                environment.getProperty("hmhb.program.outcome.maxLength", Integer.class),
+                environment.getProperty("hmhb.program.name.maxLength", Integer.class),
+                environment.getProperty("hmhb.program.otherProgramArea.explanation.maxLength", Integer.class),
+                environment.getProperty("hmhb.organization.name.maxLength", Integer.class)
         );
 
         this.privateConfig = new PrivateConfig(

--- a/src/main/java/org/hmhb/config/PublicConfig.java
+++ b/src/main/java/org/hmhb/config/PublicConfig.java
@@ -21,12 +21,29 @@ public class PublicConfig {
     private final int programCityMaxLength;
     private final int programGoalMaxLength;
     private final int programOutcomeMaxLength;
+    private final int programNameMaxLength;
+    private final int programAreaExplanationMaxLength;
+    private final int organizationNameMaxLength;
 
     /**
      * Constructs a {@link PublicConfig}.
      *
      * @param googleOauthClientId the google oauth2 client ID
      * @param urlPrefix the configured url prefix
+     * @param programStartYearMin the min start year allowed for a program
+     * @param programStreetAddressMaxLength the max chars allowed for a
+     *                                      program's street address
+     * @param programCityMaxLength the max chars allowed for a program's city
+     * @param programGoalMaxLength the max chars allowed for program's
+     *                             primary goals
+     * @param programOutcomeMaxLength the max chars allowed for a program's
+     *                                measurable outcomes
+     * @param programNameMaxLength the max chars allowed for a program's name
+     * @param programAreaExplanationMaxLength the max chars allowed for a
+     *                                        program's other-program-area
+     *                                        explanation
+     * @param organizationNameMaxLength the max chars allowed for an
+     *                                  organization's name
      */
     public PublicConfig(
             @Nonnull String googleOauthClientId,
@@ -35,7 +52,10 @@ public class PublicConfig {
             int programStreetAddressMaxLength,
             int programCityMaxLength,
             int programGoalMaxLength,
-            int programOutcomeMaxLength
+            int programOutcomeMaxLength,
+            int programNameMaxLength,
+            int programAreaExplanationMaxLength,
+            int organizationNameMaxLength
     ) {
         this.googleOauthClientId = requireNonNull(googleOauthClientId, "googleOauthClientId cannot be null");
         this.urlPrefix = urlPrefix;
@@ -44,6 +64,9 @@ public class PublicConfig {
         this.programCityMaxLength = programCityMaxLength;
         this.programGoalMaxLength = programGoalMaxLength;
         this.programOutcomeMaxLength = programOutcomeMaxLength;
+        this.programNameMaxLength = programNameMaxLength;
+        this.programAreaExplanationMaxLength = programAreaExplanationMaxLength;
+        this.organizationNameMaxLength = organizationNameMaxLength;
     }
 
     /**
@@ -65,24 +88,79 @@ public class PublicConfig {
         return urlPrefix;
     }
 
+    /**
+     * Returns the configured min start year allowed for a program.
+     *
+     * @return the min start year allowed for a program
+     */
     public int getProgramStartYearMin() {
         return programStartYearMin;
     }
 
+    /**
+     * Returns the configured max chars allowed for a program's street address.
+     *
+     * @return the max chars allowed for a program's street address
+     */
     public int getProgramStreetAddressMaxLength() {
         return programStreetAddressMaxLength;
     }
 
+    /**
+     * Returns the configured max chars allowed for a program's city.
+     *
+     * @return the max chars allowed for a program's city
+     */
     public int getProgramCityMaxLength() {
         return programCityMaxLength;
     }
 
+    /**
+     * Returns the configured max chars allowed for program's primary goals.
+     *
+     * @return the max chars allowed for program's primary goals
+     */
     public int getProgramGoalMaxLength() {
         return programGoalMaxLength;
     }
 
+    /**
+     * Returns the configured max chars allowed for program's measurable
+     * outcomes.
+     *
+     * @return the max chars allowed for program's measurable outcomes
+     */
     public int getProgramOutcomeMaxLength() {
         return programOutcomeMaxLength;
+    }
+
+    /**
+     * Returns the configured max chars allowed for a program's name.
+     *
+     * @return the max chars allowed for a program's name
+     */
+    public int getProgramNameMaxLength() {
+        return programNameMaxLength;
+    }
+
+    /**
+     * Returns the configured max chars allowed for a program's
+     * other-program-area explanation.
+     *
+     * @return the max chars allowed for a program's other-program-area
+     * explanation
+     */
+    public int getProgramAreaExplanationMaxLength() {
+        return programAreaExplanationMaxLength;
+    }
+
+    /**
+     * Returns the configured max chars allowed for an organization's name.
+     *
+     * @return the max chars allowed for an organization's name
+     */
+    public int getOrganizationNameMaxLength() {
+        return organizationNameMaxLength;
     }
 
     @Override

--- a/src/main/java/org/hmhb/exception/organization/OrganizationNameIsTooLongException.java
+++ b/src/main/java/org/hmhb/exception/organization/OrganizationNameIsTooLongException.java
@@ -1,0 +1,9 @@
+package org.hmhb.exception.organization;
+
+import org.hmhb.exception.BadRequestException;
+
+/**
+ * An exception to indicate that the passed in name for an org was too long.
+ */
+public class OrganizationNameIsTooLongException extends BadRequestException {
+}

--- a/src/main/java/org/hmhb/exception/organization/OrganizationUrlIsTooLongException.java
+++ b/src/main/java/org/hmhb/exception/organization/OrganizationUrlIsTooLongException.java
@@ -1,0 +1,9 @@
+package org.hmhb.exception.organization;
+
+import org.hmhb.exception.BadRequestException;
+
+/**
+ * An exception to indicate that the passed in URL is too long.
+ */
+public class OrganizationUrlIsTooLongException extends BadRequestException {
+}

--- a/src/main/java/org/hmhb/exception/program/ProgramNameIsTooLongException.java
+++ b/src/main/java/org/hmhb/exception/program/ProgramNameIsTooLongException.java
@@ -1,0 +1,9 @@
+package org.hmhb.exception.program;
+
+import org.hmhb.exception.BadRequestException;
+
+/**
+ * An exception to indicate that the program name is too long.
+ */
+public class ProgramNameIsTooLongException extends BadRequestException {
+}

--- a/src/main/java/org/hmhb/exception/program/ProgramOtherExplanationIsTooLongException.java
+++ b/src/main/java/org/hmhb/exception/program/ProgramOtherExplanationIsTooLongException.java
@@ -1,0 +1,9 @@
+package org.hmhb.exception.program;
+
+import org.hmhb.exception.BadRequestException;
+
+/**
+ * An exception to indicate that the other program area supplied is too long.
+ */
+public class ProgramOtherExplanationIsTooLongException extends BadRequestException {
+}

--- a/src/main/java/org/hmhb/program/DefaultProgramService.java
+++ b/src/main/java/org/hmhb/program/DefaultProgramService.java
@@ -21,9 +21,11 @@ import org.hmhb.exception.program.ProgramCityNameIsTooLongException;
 import org.hmhb.exception.program.ProgramCityRequiredException;
 import org.hmhb.exception.program.ProgramGoalIsTooLongException;
 import org.hmhb.exception.program.ProgramMeasurableOutcome1RequiredException;
+import org.hmhb.exception.program.ProgramNameIsTooLongException;
 import org.hmhb.exception.program.ProgramNameRequiredException;
 import org.hmhb.exception.program.ProgramNotFoundException;
 import org.hmhb.exception.program.ProgramOrganizationRequiredException;
+import org.hmhb.exception.program.ProgramOtherExplanationIsTooLongException;
 import org.hmhb.exception.program.ProgramOutcomeIsTooLongException;
 import org.hmhb.exception.program.ProgramPrimaryGoal1RequiredException;
 import org.hmhb.exception.program.ProgramStartYearIsTooOldException;
@@ -304,6 +306,15 @@ public class DefaultProgramService implements ProgramService {
 
         if (StringUtils.isBlank(program.getName())) {
             throw new ProgramNameRequiredException();
+        }
+
+        if (program.getName().length() > publicConfig.getProgramNameMaxLength()) {
+            throw new ProgramNameIsTooLongException();
+        }
+
+        String other = program.getOtherProgramAreaExplanation();
+        if (other != null && other.length() > publicConfig.getProgramAreaExplanationMaxLength()) {
+            throw new ProgramOtherExplanationIsTooLongException();
         }
 
         if (StringUtils.isBlank(program.getState())) {

--- a/src/test/java/org/hmhb/authentication/DefaultAuthenticationServiceTest.java
+++ b/src/test/java/org/hmhb/authentication/DefaultAuthenticationServiceTest.java
@@ -64,7 +64,7 @@ public class DefaultAuthenticationServiceTest {
                 gPlusProfile
         );
 
-        PublicConfig publicConfig = new PublicConfig(CLIENT_ID, null, 1, 2, 3, 4, 5);
+        PublicConfig publicConfig = new PublicConfig(CLIENT_ID, null, 1, 2, 3, 4, 5, 6, 7, 8);
         PrivateConfig privateConfig = new PrivateConfig(CLIENT_SECRET, "jwtDomain", "jwtSecret");
 
         /* Train the mocks. */

--- a/src/test/java/org/hmhb/authentication/DefaultJwtAuthenticationServiceTest.java
+++ b/src/test/java/org/hmhb/authentication/DefaultJwtAuthenticationServiceTest.java
@@ -44,7 +44,7 @@ public class DefaultJwtAuthenticationServiceTest {
         user.setEmail(USER_EMAIL);
         user.setAdmin(false);
 
-        PublicConfig publicConfig = new PublicConfig("oauthClientId", null, 1, 2, 3, 4, 5);
+        PublicConfig publicConfig = new PublicConfig("oauthClientId", null, 1, 2, 3, 4, 5, 6, 7, 8);
         PrivateConfig privateConfig = new PrivateConfig("oauthClientSecret", TEST_DOMAIN, TEST_SECRET);
 
         /* Train the config. */
@@ -71,7 +71,7 @@ public class DefaultJwtAuthenticationServiceTest {
         user.setEmail(USER_EMAIL);
         user.setAdmin(false);
 
-        PublicConfig publicConfig = new PublicConfig("oauthClientId", null, 1, 2, 3, 4, 5);
+        PublicConfig publicConfig = new PublicConfig("oauthClientId", null, 1, 2, 3, 4, 5, 6, 7, 8);
         PrivateConfig privateConfig = new PrivateConfig("oauthClientSecret", TEST_DOMAIN, TEST_SECRET);
 
         /* Train the config. */
@@ -121,7 +121,7 @@ public class DefaultJwtAuthenticationServiceTest {
         user.setEmail(USER_EMAIL);
         user.setAdmin(false);
 
-        PublicConfig publicConfig = new PublicConfig("oauthClientId", null, 1, 2, 3, 4, 5);
+        PublicConfig publicConfig = new PublicConfig("oauthClientId", null, 1, 2, 3, 4, 5, 6, 7, 8);
         PrivateConfig privateConfig = new PrivateConfig("oauthClientSecret", TEST_DOMAIN, TEST_SECRET);
 
         /* Train the config. */
@@ -145,7 +145,7 @@ public class DefaultJwtAuthenticationServiceTest {
         user.setEmail(USER_EMAIL);
         user.setAdmin(false);
 
-        PublicConfig publicConfig = new PublicConfig("oauthClientId", null, 1, 2, 3, 4, 5);
+        PublicConfig publicConfig = new PublicConfig("oauthClientId", null, 1, 2, 3, 4, 5, 6, 7, 8);
         PrivateConfig privateConfig = new PrivateConfig("oauthClientSecret", TEST_DOMAIN, TEST_SECRET);
 
         /* Train the config. */

--- a/src/test/java/org/hmhb/config/ConfigControllerTest.java
+++ b/src/test/java/org/hmhb/config/ConfigControllerTest.java
@@ -42,6 +42,9 @@ public class ConfigControllerTest {
         int programCityMaxLen = 3333;
         int programGoalMaxLen = 4444;
         int programOutcomeMaxLen = 5555;
+        int programNameMaxLen = 6666;
+        int programOtherExplanationMaxLen = 7777;
+        int orgNameMaxLen = 8888;
 
         PublicConfig publicConfig = new PublicConfig(
                 oauthClientId,
@@ -50,7 +53,10 @@ public class ConfigControllerTest {
                 programStreetAddressMaxLen,
                 programCityMaxLen,
                 programGoalMaxLen,
-                programOutcomeMaxLen
+                programOutcomeMaxLen,
+                programNameMaxLen,
+                programOtherExplanationMaxLen,
+                orgNameMaxLen
         );
 
         /* Train the mocks. */
@@ -69,6 +75,12 @@ public class ConfigControllerTest {
         assertTrue(assertErrMsg, actual.contains("\"programCityMaxLength\":" + programCityMaxLen));
         assertTrue(assertErrMsg, actual.contains("\"programGoalMaxLength\":" + programGoalMaxLen));
         assertTrue(assertErrMsg, actual.contains("\"programOutcomeMaxLength\":" + programOutcomeMaxLen));
+        assertTrue(assertErrMsg, actual.contains("\"programNameMaxLength\":" + programNameMaxLen));
+        assertTrue(
+                assertErrMsg,
+                actual.contains("\"programAreaExplanationMaxLength\":" + programOtherExplanationMaxLen)
+        );
+        assertTrue(assertErrMsg, actual.contains("\"organizationNameMaxLength\":" + orgNameMaxLen));
 
         /* Verify the response wont be cached. */
         verify(response).setHeader("Cache-Control", "max-age=0, must-revalidate");

--- a/src/test/java/org/hmhb/config/DefaultConfigServiceTest.java
+++ b/src/test/java/org/hmhb/config/DefaultConfigServiceTest.java
@@ -20,8 +20,11 @@ public class DefaultConfigServiceTest {
     private static final Integer PROG_START_YEAR_MIN = 1500;
     private static final Integer PROG_STREET_ADDR_MAX_LEN = 70;
     private static final Integer PROG_CITY_MAX_LEN = 50;
-    private static final Integer PROG_GOAL_MAX_LEN = 500;
-    private static final Integer PROG_OUTCOME_MAX_LEN = 500;
+    private static final Integer PROG_GOAL_MAX_LEN = 501;
+    private static final Integer PROG_OUTCOME_MAX_LEN = 502;
+    private static final Integer PROG_NAME_MAX_LEN = 101;
+    private static final Integer PROG_OTHER_EXPL_MAX_LEN = 101;
+    private static final Integer ORG_NAME_MAX_LEN = 102;
 
     private DefaultConfigService toTest;
 
@@ -36,10 +39,15 @@ public class DefaultConfigServiceTest {
         when(environment.getProperty("hmhb.jwt.domain")).thenReturn(JWT_DOMAIN);
         when(environment.getProperty("hmhb.jwt.secret")).thenReturn(JWT_SECRET);
         when(environment.getProperty("hmhb.program.startYear.minValue", Integer.class)).thenReturn(PROG_START_YEAR_MIN);
-        when(environment.getProperty("hmhb.program.streetAddress.maxLength", Integer.class)).thenReturn(PROG_STREET_ADDR_MAX_LEN);
+        when(environment.getProperty("hmhb.program.streetAddress.maxLength", Integer.class))
+                .thenReturn(PROG_STREET_ADDR_MAX_LEN);
         when(environment.getProperty("hmhb.program.city.maxLength", Integer.class)).thenReturn(PROG_CITY_MAX_LEN);
         when(environment.getProperty("hmhb.program.goal.maxLength", Integer.class)).thenReturn(PROG_GOAL_MAX_LEN);
         when(environment.getProperty("hmhb.program.outcome.maxLength", Integer.class)).thenReturn(PROG_OUTCOME_MAX_LEN);
+        when(environment.getProperty("hmhb.program.name.maxLength", Integer.class)).thenReturn(PROG_NAME_MAX_LEN);
+        when(environment.getProperty("hmhb.program.otherProgramArea.explanation.maxLength", Integer.class))
+                .thenReturn(PROG_OTHER_EXPL_MAX_LEN);
+        when(environment.getProperty("hmhb.organization.name.maxLength", Integer.class)).thenReturn(ORG_NAME_MAX_LEN);
 
         toTest = new DefaultConfigService(environment);
     }
@@ -53,7 +61,10 @@ public class DefaultConfigServiceTest {
                 PROG_STREET_ADDR_MAX_LEN,
                 PROG_CITY_MAX_LEN,
                 PROG_GOAL_MAX_LEN,
-                PROG_OUTCOME_MAX_LEN
+                PROG_OUTCOME_MAX_LEN,
+                PROG_NAME_MAX_LEN,
+                PROG_OTHER_EXPL_MAX_LEN,
+                ORG_NAME_MAX_LEN
         );
 
         /* Make the call. */

--- a/src/test/java/org/hmhb/program/DefaultProgramServiceTest.java
+++ b/src/test/java/org/hmhb/program/DefaultProgramServiceTest.java
@@ -16,9 +16,11 @@ import org.hmhb.exception.program.ProgramCityNameIsTooLongException;
 import org.hmhb.exception.program.ProgramCityRequiredException;
 import org.hmhb.exception.program.ProgramGoalIsTooLongException;
 import org.hmhb.exception.program.ProgramMeasurableOutcome1RequiredException;
+import org.hmhb.exception.program.ProgramNameIsTooLongException;
 import org.hmhb.exception.program.ProgramNameRequiredException;
 import org.hmhb.exception.program.ProgramNotFoundException;
 import org.hmhb.exception.program.ProgramOrganizationRequiredException;
+import org.hmhb.exception.program.ProgramOtherExplanationIsTooLongException;
 import org.hmhb.exception.program.ProgramOutcomeIsTooLongException;
 import org.hmhb.exception.program.ProgramPrimaryGoal1RequiredException;
 import org.hmhb.exception.program.ProgramStartYearIsTooOldException;
@@ -92,6 +94,9 @@ public class DefaultProgramServiceTest {
                 "test-oauth-client-id",
                 "test-url-prefix",
                 MIN_VALUE,
+                MAX_LEN,
+                MAX_LEN,
+                MAX_LEN,
                 MAX_LEN,
                 MAX_LEN,
                 MAX_LEN,
@@ -291,6 +296,30 @@ public class DefaultProgramServiceTest {
     public void testSaveCreateNew_StartYearTooOld() {
         Program input = createFilledInProgram();
         input.setStartYear(TOO_OLD);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+
+        /* Make the call. */
+        toTest.save(input);
+    }
+
+    @Test(expected = ProgramNameIsTooLongException.class)
+    public void testSaveCreateNew_NameTooLong() {
+        Program input = createFilledInProgram();
+        input.setName(TOO_LONG);
+
+        /* Train the mocks. */
+        when(authorizationService.isAdmin()).thenReturn(true);
+
+        /* Make the call. */
+        toTest.save(input);
+    }
+
+    @Test(expected = ProgramOtherExplanationIsTooLongException.class)
+    public void testSaveCreateNew_OtherExplanationTooLong() {
+        Program input = createFilledInProgram();
+        input.setOtherProgramAreaExplanation(TOO_LONG);
 
         /* Train the mocks. */
         when(authorizationService.isAdmin()).thenReturn(true);

--- a/src/test/java/org/hmhb/url/DefaultUrlServiceTest.java
+++ b/src/test/java/org/hmhb/url/DefaultUrlServiceTest.java
@@ -32,7 +32,7 @@ public class DefaultUrlServiceTest {
     public void testGetUrlPrefix() throws Exception {
         String expected = "https://hmhb.herokuapp.com:443";
 
-        PublicConfig publicConfig = new PublicConfig("oauthClientId", null, 1, 2, 3, 4, 5);
+        PublicConfig publicConfig = new PublicConfig("oauthClientId", null, 1, 2, 3, 4, 5, 6, 7, 8);
         PrivateConfig privateConfig = new PrivateConfig("oauthClientSecret", "jwtDomain", "jwtSecret");
 
         /* Train the config. */
@@ -55,7 +55,7 @@ public class DefaultUrlServiceTest {
     public void testGetUrlPrefixNoPortSpecified() throws Exception {
         String expected = "https://hmhb.herokuapp.com";
 
-        PublicConfig publicConfig = new PublicConfig("oauthClientId", null, 1, 2, 3, 4, 5);
+        PublicConfig publicConfig = new PublicConfig("oauthClientId", null, 1, 2, 3, 4, 5, 6, 7, 8);
         PrivateConfig privateConfig = new PrivateConfig("oauthClientSecret", "jwtDomain", "jwtSecret");
 
         /* Train the config. */
@@ -78,7 +78,7 @@ public class DefaultUrlServiceTest {
     public void testGetUrlPrefixConfigOverride() throws Exception {
         String expected = "https://hmhb.herokuapp.com";
 
-        PublicConfig publicConfig = new PublicConfig("oauthClientId", expected, 1, 2, 3, 4, 5);
+        PublicConfig publicConfig = new PublicConfig("oauthClientId", expected, 1, 2, 3, 4, 5, 6, 7, 8);
         PrivateConfig privateConfig = new PrivateConfig("oauthClientSecret", "jwtDomain", "jwtSecret");
 
         /* Train the config. */
@@ -101,7 +101,7 @@ public class DefaultUrlServiceTest {
     public void testGetUrlPrefixConfigOverrideIsEmpty() throws Exception {
         String expected = "http://localhost:8080";
 
-        PublicConfig publicConfig = new PublicConfig("oauthClientId", "", 1, 2, 3, 4, 5);
+        PublicConfig publicConfig = new PublicConfig("oauthClientId", "", 1, 2, 3, 4, 5, 6, 7, 8);
         PrivateConfig privateConfig = new PrivateConfig("oauthClientSecret", "jwtDomain", "jwtSecret");
 
         /* Train the config. */
@@ -124,7 +124,7 @@ public class DefaultUrlServiceTest {
     public void testGetUrlPrefixConfigOverrideIsSpace() throws Exception {
         String expected = "http://localhost:8080";
 
-        PublicConfig publicConfig = new PublicConfig("oauthClientId", "   ", 1, 2, 3, 4, 5);
+        PublicConfig publicConfig = new PublicConfig("oauthClientId", "   ", 1, 2, 3, 4, 5, 6, 7, 8);
         PrivateConfig privateConfig = new PrivateConfig("oauthClientSecret", "jwtDomain", "jwtSecret");
 
         /* Train the config. */


### PR DESCRIPTION
* Adds config for max length of org name, prog name, and prog area explanation.
* Adds max length validation for organization name.
* Adds max length validation for program name.
* Adds max length validation for program area explanation.
* Adds server side max length validation for the facebook and website URLs.
* Updates the unit tests.